### PR TITLE
Modify the log endpoint to include timestamp/id on each entry

### DIFF
--- a/logBuffer.js
+++ b/logBuffer.js
@@ -1,0 +1,47 @@
+class LogBuffer {
+    constructor(size = 1000) {
+        this.size = size;
+        this.buffer = new Array(this.size);
+        this.head = 0;
+        this.wrapped = false
+        this.lastLogTimestamp = 0;
+        this.lastLogTimestampCount = 0;
+    }
+
+    add(logEntry) {
+
+        let now = Date.now();
+        if (now == this.lastLogTimestamp) {
+            this.lastLogTimestampCount++
+        } else {
+            this.lastLogTimestamp = now
+            this.lastLogTimestampCount = 0
+        }
+        const entry = { ts: now+(""+this.lastLogTimestampCount).padStart(4,"0"), msg: logEntry}
+
+        this.buffer[this.head++] = entry;
+        if (this.head === this.size) {
+            this.head = 0
+            this.wrapped = true;
+        }
+        return entry;
+    }
+
+    clear() {
+        this.buffer = new Array(this.size);
+        this.head = 0;
+        this.wrapped = false;
+    }
+
+    toArray() {
+        if (!this.wrapped) {
+            return this.buffer.slice(0,this.head)
+        } else {
+            const result = this.buffer.slice(this.head, this.size);
+            result.push( ... this.buffer.slice(0,this.head) )
+            return result;
+        }
+    }
+}
+
+module.exports = LogBuffer


### PR DESCRIPTION
The `/flowforge/log` endpoint now returns an array of log objects, rather than raw strings:

```
[
    {
        "ts": "16389862896890000",
        "msg": "8 Dec 17:58:09 - [info] \n\nWelcome to Node-RED\n===================\n\n"
    },
    {
        "ts": "16389862896890001",
        "msg": "8 Dec 17:58:09 - [info] Node-RED version: v2.1.3-git\n"
    }
]
```

The `ts` field is the time in millisecs plus a padded 4-digit sequence number (so we can have 1000 log entries in a single millisec and keep the ts value unique).

Note: just realised I haven't updated the websocket endpoint to match - it still emits just the log message. Will tidy that up separately.