### PR TITLE
Add support for max-old-space-size

### DIFF
--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -121,14 +121,20 @@ class Launcher {
             cwd: path.join(this.settings.rootDir, this.settings.userDir)
         }
 
+        const processArguments = [
+            "-u",
+            path.join(this.settings.rootDir,this.settings.userDir),
+            "-p",
+            this.settings.port
+        ]
+
+        if (this.settings.stack?.['memory'] && /^[1-9]\d*$/.test(this.settings.stack['memory'])) {
+            processArguments.push(`--max-old-space-size=${this.settings.stack['memory']}`)
+        }
+
         this.proc = childProcess.spawn(
             this.options.execPath,
-            [
-                "-u",
-                path.join(this.settings.rootDir,this.settings.userDir),
-                "-p",
-                this.settings.port
-            ],
+            processArguments,
             processOptions
         )
 


### PR DESCRIPTION
With this PR, the launcher can be started with `--max-old-space-size=512` and it will pass that through to the node.js process is spawns for Node-RED.

This is a piece of the Stacks work - allowing a stack to limit the memory usage of an instance. Whilst max-old-space-size doesn't provide a hard limit, it is important to set it when there is a hard limit (such as in a container).

There will be separate PRs for the drivers to pass this value in based on the stack definition being used.

For localfs it will be the stack defined value. For the others, it will be ~75% of the stack defined value so that node will kick in with its gc before hitting 100%.