### PR TITLE
FIX: Publish package on push to `main` and on schedule

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,6 +18,9 @@ jobs:
 
   nrLauncherPackage:
     needs: build
+    if: |
+      ( github.event_name == 'push' && github.ref == 'refs/heads/main' ) ||
+      github.event_name == 'schedule'
     uses: 'flowforge/github-actions-workflows/.github/workflows/publish_node_package.yml@main'
     with:
       package_name: flowforge-nr-launcher
@@ -29,6 +32,9 @@ jobs:
   
   nrThemePackage:
     needs: build
+    if: |
+      ( github.event_name == 'push' && github.ref == 'refs/heads/main' ) ||
+      github.event_name == 'schedule'
     uses: 'flowforge/github-actions-workflows/.github/workflows/publish_node_package.yml@main'
     with:
       package_name: flowforge-nr-theme


### PR DESCRIPTION
## Description

Temporarily - run publish package job when changes are pushed to the `main` branch and on schedule.

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `flowforge/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `flowforge/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

