### PR TITLE
Update project nodes for new org

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -40,7 +40,7 @@ jobs:
       package_name: flowforge-nr-launcher
       publish_package: true
       package_dependencies: |
-        @flowforge/nr-project-nodes
+        @flowfuse/nr-project-nodes
         @flowfuse/nr-file-nodes
     secrets:
       npm_registry_token: ${{ secrets.NPM_PUBLISH_TOKEN }}

--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -135,7 +135,7 @@ class Launcher {
         } else if (this.settings.nodesDir && typeof this.settings.nodesDir === 'string') {
             nodesDir.push(this.settings.nodesDir)
         }
-        nodesDir.push(path.join(require.main.path, 'node_modules', '@flowforge', 'nr-project-nodes').replace(/\\/g, '/'))
+        nodesDir.push(path.join(require.main.path, 'node_modules', '@flowfuse', 'nr-project-nodes').replace(/\\/g, '/'))
         nodesDir.push(path.join(require.main.path, '..', 'nr-project-nodes').replace(/\\/g, '/'))
         nodesDir.push(path.join(require.main.path, 'node_modules', '@flowfuse', 'nr-file-nodes').replace(/\\/g, '/'))
         nodesDir.push(path.join(require.main.path, '..', 'nr-file-nodes').replace(/\\/g, '/'))

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
             "version": "1.12.0",
             "license": "Apache-2.0",
             "dependencies": {
-                "@flowforge/nr-project-nodes": "^0.4.0",
                 "@flowfuse/nr-file-nodes": "^0.0.4",
+                "@flowfuse/nr-project-nodes": "^0.5.0",
                 "@node-red/util": "^3.1.0",
                 "body-parser": "^1.20.2",
                 "command-line-args": "^5.2.1",
@@ -1026,18 +1026,6 @@
                 "node": ">=10"
             }
         },
-        "node_modules/@flowforge/nr-project-nodes": {
-            "version": "0.4.0",
-            "resolved": "https://registry.npmjs.org/@flowforge/nr-project-nodes/-/nr-project-nodes-0.4.0.tgz",
-            "integrity": "sha512-1q4LCB6qNqsQVfNB1Qo/dEOdw7Ma1CrRxd6Mml0o/Uyd4lei/SmzSRBXsvdZDu0DNGkYSCuX7w96Z5DeE77/cg==",
-            "dependencies": {
-                "got": "^11.8.6",
-                "mqtt": "^4.3.7"
-            },
-            "engines": {
-                "node": ">=16.x"
-            }
-        },
         "node_modules/@flowfuse/nr-file-nodes": {
             "version": "0.0.4",
             "resolved": "https://registry.npmjs.org/@flowfuse/nr-file-nodes/-/nr-file-nodes-0.0.4.tgz",
@@ -1072,6 +1060,18 @@
             },
             "funding": {
                 "url": "https://github.com/sindresorhus/got?sponsor=1"
+            }
+        },
+        "node_modules/@flowfuse/nr-project-nodes": {
+            "version": "0.5.0",
+            "resolved": "https://registry.npmjs.org/@flowfuse/nr-project-nodes/-/nr-project-nodes-0.5.0.tgz",
+            "integrity": "sha512-F9j/b7T2R4tl2Rc5w7g/L984OAyDrEeGYkKEXItzKeRP2OGothyG3yfJYj4DcXL6ehCTeDlBY0O8ifpGnGQV1g==",
+            "dependencies": {
+                "got": "^11.8.6",
+                "mqtt": "^4.3.7"
+            },
+            "engines": {
+                "node": ">=16.x"
             }
         },
         "node_modules/@gar/promisify": {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "homepage": "https://github.com/FlowFuse/nr-launcher#readme",
     "dependencies": {
         "@flowfuse/nr-file-nodes": "^0.0.4",
-        "@flowforge/nr-project-nodes": "^0.4.0",
+        "@flowfuse/nr-project-nodes": "^0.5.0",
         "@node-red/util": "^3.1.0",
         "body-parser": "^1.20.2",
         "command-line-args": "^5.2.1",


### PR DESCRIPTION
## Description

Update to pull in project nodes from new org name.

~In draft until https://github.com/FlowFuse/nr-project-nodes/pull/52 is merged and new release made so we can update the `package-lock.json` file in this PR to match. 🐔/🥚~ 