### PR TITLE
Fix Node-RED src path for automation build

### DIFF
--- a/lib/theme/scripts/build.js
+++ b/lib/theme/scripts/build.js
@@ -35,18 +35,26 @@ if (!values.src) {
     console.warn('Missing variable: src')
     showUsageAndExit(1)
 }
-if (!existsSync(values.src)) {
-    console.warn(`Node-RED directory '${values.src}' not found`)
+
+const nrPackagePath = path.resolve(values.src) // absolute version of path provided
+const nrPackageFile = path.join(nrPackagePath, 'package.json')
+
+if (!existsSync(nrPackagePath)) {
+    console.warn(`Node-RED directory '${nrPackagePath}' not found`)
     showUsageAndExit(1)
 }
-if (!existsSync(path.join(values.src, '/package.json'))) {
-    console.warn(`Node-RED path is not valid. Could not find '${path.join(values.src, '/package.json')}'`)
+if (!existsSync(nrPackageFile)) {
+    console.warn(`Node-RED path is not valid. Could not find '${nrPackageFile}'`)
     showUsageAndExit(2)
 }
-if (!existsSync(path.join(values.src, SASS_DIR))) {
-    console.warn(`Node-RED path is not valid. Could not find '${path.join(values.src, SASS_DIR)}'`)
+if (!existsSync(path.join(nrPackagePath, SASS_DIR))) {
+    console.warn(`Node-RED path is not valid. Could not find '${path.join(nrPackagePath, SASS_DIR)}'`)
     showUsageAndExit(3)
 }
+
+// append the verified absolute path of node-red/package.json to the values object
+values.nrPackagePath = nrPackagePath
+values.nrPackageFile = nrPackageFile;
 
 (async function () {
     const themes = [
@@ -74,7 +82,7 @@ async function generateTheme (options) {
         }
     }
     // Load base colours
-    const colorsFile = await readFile(path.join(options.src, SASS_DIR, 'colors.scss'), 'utf-8')
+    const colorsFile = await readFile(path.join(options.nrPackagePath, SASS_DIR, 'colors.scss'), 'utf-8')
     const updatedColors = []
 
     while ((match = RULE_REGEX.exec(colorsFile)) !== null) {
@@ -83,7 +91,7 @@ async function generateTheme (options) {
 
     const tmpDir = os.tmpdir()
     const workingDir = await mkdtemp(`${tmpDir}${path.sep}`)
-    await cp(path.join(options.src, SASS_DIR), workingDir, { recursive: true })
+    await cp(path.join(options.nrPackagePath, SASS_DIR), workingDir, { recursive: true })
     await writeFile(path.join(workingDir, 'colors.scss'), updatedColors.join('\n'))
     const result = sass.compile(path.join(workingDir, 'style.scss'), { outputStyle: 'expanded' })
     const css = result.css.toString()
@@ -112,12 +120,7 @@ async function generateTheme (options) {
         }
     })
 
-    let nrPkg
-    if (path.isAbsolute(options.src)) {
-        nrPkg = require(path.join(options.src, 'package.json'))
-    } else {
-        nrPkg = require(path.join(__dirname, options.src, 'package.json'))
-    }
+    const nrPkg = require(options.nrPackageFile)
     const now = new Date().toISOString()
 
     const header = `/*


### PR DESCRIPTION
## Description

Ensures the path tested at the start of the script is the same path used to load the `package.json`

## Related Issue(s)

#153


