### PR TITLE
Add NODE_OPTIONS env var to npm install

### DIFF
--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -219,10 +219,15 @@ class Launcher {
             fs.writeFileSync(pkgFilePath, JSON.stringify(pkg, null, 2))
             const npmCommand = process.platform === 'win32' ? 'npm.cmd' : 'npm'
             return new Promise((resolve, reject) => {
+                const env = {}
+                if (this.settings.stack.memory) {
+                    const memLimit = Math.round(this.settings.stack.memory * 0.75)
+                    env.NODE_OPTIONS = `--max-old-space=${memLimit}`
+                }
                 const child = childProcess.spawn(
                     npmCommand,
                     ['install', '--omit=dev', '--no-audit', '--no-update-notifier', '--no-fund'],
-                    { windowsHide: true, cwd: path.join(this.settings.rootDir, this.settings.userDir) })
+                    { windowsHide: true, cwd: path.join(this.settings.rootDir, this.settings.userDir), env })
                 child.stdout.on('data', (data) => {
                     this.logBuffer.add({ level: 'system', msg: '[npm] ' + data })
                 })


### PR DESCRIPTION
part of #194

## Description

<!-- Describe your changes in detail -->
Set the max-old-space for npm when doing the initial install to try and prevent the process getting killed by the OOM reaper (or at least try and limit heap size to with in the bounds)

## Related Issue(s)

<!-- What issue does this PR relate to? -->
part of #194

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

