### PR TITLE
Run npm install with instance env vars

### DIFF
--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -217,7 +217,7 @@ class Launcher {
             this.logBuffer.add({ level: 'system', msg: 'Updating project dependencies' })
             pkg.dependencies = wantedDependencies
             fs.writeFileSync(pkgFilePath, JSON.stringify(pkg, null, 2))
-            const npmEnv = Object.assign(process.env, this.settings.env)
+            const npmEnv = Object.assign({}, process.env, this.settings.env)
             const npmCommand = process.platform === 'win32' ? 'npm.cmd' : 'npm'
             return new Promise((resolve, reject) => {
                 const child = childProcess.spawn(

--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -217,7 +217,7 @@ class Launcher {
             this.logBuffer.add({ level: 'system', msg: 'Updating project dependencies' })
             pkg.dependencies = wantedDependencies
             fs.writeFileSync(pkgFilePath, JSON.stringify(pkg, null, 2))
-            const npmEnv = this.settings.env
+            const npmEnv = Object.assign(process.env, this.settings.env)
             const npmCommand = process.platform === 'win32' ? 'npm.cmd' : 'npm'
             return new Promise((resolve, reject) => {
                 const child = childProcess.spawn(

--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -217,12 +217,13 @@ class Launcher {
             this.logBuffer.add({ level: 'system', msg: 'Updating project dependencies' })
             pkg.dependencies = wantedDependencies
             fs.writeFileSync(pkgFilePath, JSON.stringify(pkg, null, 2))
+            const npmEnv = this.settings.env
             const npmCommand = process.platform === 'win32' ? 'npm.cmd' : 'npm'
             return new Promise((resolve, reject) => {
                 const child = childProcess.spawn(
                     npmCommand,
                     ['install', '--omit=dev', '--no-audit', '--no-update-notifier', '--no-fund'],
-                    { windowsHide: true, cwd: path.join(this.settings.rootDir, this.settings.userDir) })
+                    { windowsHide: true, cwd: path.join(this.settings.rootDir, this.settings.userDir), env: npmEnv })
                 child.stdout.on('data', (data) => {
                     this.logBuffer.add({ level: 'system', msg: '[npm] ' + data })
                 })


### PR DESCRIPTION
fixes FlowFuse/flowfuse#3362

## Description

<!-- Describe your changes in detail -->
This ensures HTTP_PROXY values are set for npm install

## Related Issue(s)

<!-- What issue does this PR relate to? -->
FlowFuse/flowfuse#3362

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

