### PR TITLE
Http node auth token

### DIFF
--- a/lib/auth/httpAuthMiddleware.js
+++ b/lib/auth/httpAuthMiddleware.js
@@ -20,11 +20,8 @@ module.exports = {
                     if (req.session.ffSession) {
                         next()
                     } else if (req.get('Authorization')?.startsWith('Bearer')) {
-                        // need to make a HTTP request against the forge platform to check
-                        // the token. Should we cache the token to reduce round trip on every
-                        // request?
                         // We should include the Project ID and the path along with the token
-                        // to be checked
+                        // to be checked to allow scoping tokens
                         const token = req.get('Authorization').split(' ')[1]
                         const cacheHit = httpTokenCache[token]
                         if (cacheHit) {

--- a/lib/auth/httpAuthMiddleware.js
+++ b/lib/auth/httpAuthMiddleware.js
@@ -1,4 +1,5 @@
 const crypto = require('crypto')
+const got = require('got')
 const session = require('express-session')
 const MemoryStore = require('memorystore')(session)
 const { Passport } = require('passport')
@@ -7,31 +8,53 @@ const { Strategy } = require('./strategy')
 let options
 let passport
 let httpNodeApp
+let client
 
 module.exports = {
     init (_options) {
         options = _options
-        return (req, res, next) => {
-            try {
-                if (req.session.ffSession) {
-                    next()
-                } else if (req.get('Authorization')?.startsWith('Bearer')) {
-                    // need to make a HTTP request against the forge platform to check
-                    // the token. We should cache the token to reduce round trip on every
-                    // request.
-                    // We should include the Project ID and the path along with the token
-                    // to be checked
-                    console.log('Token auth')
-                    next()
-                } else {
-                    req.session.redirectTo = req.originalUrl
-                    passport.authenticate('FlowFuse', { session: false })(req, res, next)
+        return [
+            async (req, res, next) => {
+                try {
+                    if (req.session.ffSession) {
+                        next()
+                    } else if (req.get('Authorization')?.startsWith('Bearer')) {
+                        // need to make a HTTP request against the forge platform to check
+                        // the token. Should we cache the token to reduce round trip on every
+                        // request?
+                        // We should include the Project ID and the path along with the token
+                        // to be checked
+                        const token = req.get('Authorization').split(' ')[1]
+                        const query = {
+                            path: req.path
+                        }
+                        try {
+                            const result = await client.get(options.projectId, {
+                                headers: {
+                                    authorization: `Bearer ${token}`
+                                },
+                                searchParams: query
+                            })
+                            next()
+                        } catch (err) {
+                            console.log(err)
+                            const error = new Error('Failed to check token')
+                            error.status = 401
+                            next(error)
+                        }
+                    } else {
+                        req.session.redirectTo = req.originalUrl
+                        passport.authenticate('FlowFuse', { session: false })(req, res, next)
+                    }
+                } catch (err) {
+                    console.log(err.stack)
+                    throw err
                 }
-            } catch (err) {
-                console.log(err.stack)
-                throw err
+            },
+            (err, req, res, next) => {
+                res.status(err.status).send()
             }
-        }
+        ]
     },
 
     setupAuthRoutes (app) {
@@ -95,6 +118,17 @@ module.exports = {
                 res.redirect(redirectTo)
             } else {
                 res.redirect('/')
+            }
+        })
+
+        // need to decide on the path here
+        client = got.extend({
+            prefixUrl: `${options.forgeURL}/account/check/http`,
+            headers: {
+                'user-agent': 'FlowFuse HTTP Node Auth',
+            },
+            timeout: {
+                request: 500
             }
         })
     }

--- a/lib/auth/httpAuthMiddleware.js
+++ b/lib/auth/httpAuthMiddleware.js
@@ -26,7 +26,7 @@ module.exports = {
                         // We should include the Project ID and the path along with the token
                         // to be checked
                         const token = req.get('Authorization').split(' ')[1]
-                        const cacheHit = httpTokenCache[token] 
+                        const cacheHit = httpTokenCache[token]
                         if (cacheHit) {
                             const age = (Date.now() - cacheHit.age) / 1000
                             if (age < 300) {
@@ -39,7 +39,7 @@ module.exports = {
                             path: req.path
                         }
                         try {
-                            const result = await client.get(options.projectId, {
+                            await client.get(options.projectId, {
                                 headers: {
                                     authorization: `Bearer ${token}`
                                 },
@@ -136,7 +136,7 @@ module.exports = {
         client = got.extend({
             prefixUrl: `${options.forgeURL}/account/check/http`,
             headers: {
-                'user-agent': 'FlowFuse HTTP Node Auth',
+                'user-agent': 'FlowFuse HTTP Node Auth'
             },
             timeout: {
                 request: 500

--- a/lib/auth/httpAuthMiddleware.js
+++ b/lib/auth/httpAuthMiddleware.js
@@ -9,6 +9,7 @@ let options
 let passport
 let httpNodeApp
 let client
+const httpTokenCache = {}
 
 module.exports = {
     init (_options) {
@@ -25,6 +26,15 @@ module.exports = {
                         // We should include the Project ID and the path along with the token
                         // to be checked
                         const token = req.get('Authorization').split(' ')[1]
+                        const cacheHit = httpTokenCache[token] 
+                        if (cacheHit) {
+                            const age = (Date.now() - cacheHit.age) / 1000
+                            if (age < 300) {
+                                next()
+                                return
+                            }
+                            delete httpTokenCache[token]
+                        }
                         const query = {
                             path: req.path
                         }
@@ -35,9 +45,10 @@ module.exports = {
                                 },
                                 searchParams: query
                             })
+                            httpTokenCache[token] = { age: Date.now() }
                             next()
                         } catch (err) {
-                            console.log(err)
+                            // console.log(err)
                             const error = new Error('Failed to check token')
                             error.status = 401
                             next(error)

--- a/lib/auth/httpAuthMiddleware.js
+++ b/lib/auth/httpAuthMiddleware.js
@@ -15,6 +15,14 @@ module.exports = {
             try {
                 if (req.session.ffSession) {
                     next()
+                } else if (req.get('Authorization')?.startsWith('Bearer')) {
+                    // need to make a HTTP request against the forge platform to check
+                    // the token. We should cache the token to reduce round trip on every
+                    // request.
+                    // We should include the Project ID and the path along with the token
+                    // to be checked
+                    console.log('Token auth')
+                    next()
                 } else {
                     req.session.redirectTo = req.originalUrl
                     passport.authenticate('FlowFuse', { session: false })(req, res, next)

--- a/lib/runtimeSettings.js
+++ b/lib/runtimeSettings.js
@@ -44,7 +44,8 @@ function getSettingsFile (settings) {
     baseURL: '${settings.baseURL}',
     forgeURL: '${settings.forgeURL}',
     clientID: '${settings.clientID}',
-    clientSecret: '${settings.clientSecret}'
+    clientSecret: '${settings.clientSecret}',
+    projectId: '${settings.projectID}'
 })`
             projectSettings.httpNodeMiddleware = 'httpNodeMiddleware: flowforgeAuthMiddleware,'
         }

--- a/test/unit/lib/runtimeSettings_spec.js
+++ b/test/unit/lib/runtimeSettings_spec.js
@@ -260,12 +260,18 @@ describe('Runtime Settings', function () {
             const settings = await loadSettings(result)
             settings.should.not.have.property('httpNodeAuth')
             settings.should.have.property('httpNodeMiddleware')
-            ;(typeof settings.httpNodeMiddleware).should.equal('function')
+            settings.httpNodeMiddleware.should.be.an.Array()
+            ;(typeof settings.httpNodeMiddleware[0]).should.equal('function')
+            ;(typeof settings.httpNodeMiddleware[1]).should.equal('function')
             settings.should.have.property('ui')
             settings.ui.should.not.have.property('path')
             settings.ui.should.have.property('middleware')
-            ;(typeof settings.ui.middleware).should.equal('function')
+            console.log(settings.ui.middleware)
+            settings.ui.middleware.should.be.an.Array()
+            ;(typeof settings.ui.middleware[0]).should.equal('function')
+            ;(typeof settings.ui.middleware[1]).should.equal('function')
         } catch (err) {
+            console.log(err)
             // Temporary fix as this module will not be found when running in CI
             // until we publish the release of the new nr-auth module.
             err.toString().should.match(/Cannot find module '@flowfuse\/nr-auth\/middleware'/)
@@ -283,7 +289,9 @@ describe('Runtime Settings', function () {
             settings.should.have.property('ui')
             settings.ui.should.have.property('path', '/foo')
             settings.ui.should.have.property('middleware')
-            ;(typeof settings.ui.middleware).should.equal('function')
+            settings.ui.middleware.should.be.an.Array()
+            ;(typeof settings.ui.middleware[0]).should.equal('function')
+            ;(typeof settings.ui.middleware[1]).should.equal('function')
         } catch (err) {
             // Temporary fix as this module will not be found when running in CI
             // until we publish the release of the new nr-auth module.


### PR DESCRIPTION
part of https://github.com/FlowFuse/flowfuse/issues/2964
## Description

<!-- Describe your changes in detail -->
Add support for HTTP Bearer tokens for HTTP-in/HTTP-out endpoints when FF auth enabled.

Depends on https://github.com/FlowFuse/flowfuse/pull/3535

## Related Issue(s)

<!-- What issue does this PR relate to? -->
https://github.com/FlowFuse/flowfuse/issues/2964

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

