### PR TITLE
Provide better health check message when waiting for NR to start

### DIFF
--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -423,7 +423,11 @@ class Launcher {
                 const res = await got.head(pollUrl, opts)
                 statusCode = res.statusCode || 500
             } catch (error) {
-                this.logBuffer.add({ level: 'system', msg: `Node-RED health check failed: ${error.toString()} (${pollUrl})` })
+                if (this.state === States.STARTING) {
+                    this.logBuffer.add({ level: 'system', msg: 'Node-RED health check: waiting for Node-RED to start' })
+                } else {
+                    this.logBuffer.add({ level: 'system', msg: `Node-RED health check failed: ${error.toString()} (${pollUrl})` })
+                }
                 console.log('Failed to poll NR on ', pollUrl, error)
                 statusCode = error.response?.statusCode || 500
             }


### PR DESCRIPTION
Fixes #213 

If the health-check fails to ping Node-RED and we know NR is still starting, we will now log:

```
Node-RED health check: waiting for Node-RED to start
```

Rather than the more alarming 'failed' message.

Tested locally with a NR stack hacked to start slowly.