### PR TITLE
Add apiMaxLength & debugMaxLength settings

### DIFF
--- a/lib/runtimeSettings.js
+++ b/lib/runtimeSettings.js
@@ -27,9 +27,11 @@ function getSettingsFile (settings) {
         httpNodeAuth: '',
         setupAuthMiddleware: '',
         httpNodeMiddleware: '',
+        apiMaxLength: '',
         tcpInAllowInboundConnections: '',
         udpInAllowInboundConnections: '',
         tours: true,
+        debugMaxLength: '',
         libraries: ''
     }
     let authMiddlewareRequired = false
@@ -124,6 +126,12 @@ function getSettingsFile (settings) {
         if (settings.settings.disableTours) {
             projectSettings.tours = false
         }
+        if (settings.settings.apiMaxLength) {
+            projectSettings.apiMaxLength = `apiMaxLength: "${settings.settings.apiMaxLength}",`
+        }
+        if (settings.settings.debugMaxLength) {
+            projectSettings.debugMaxLength = `debugMaxLength: ${settings.settings.debugMaxLength},`
+        }
     }
 
     if (settings.features?.projectComms && settings.broker) {
@@ -207,6 +215,8 @@ module.exports = {
     ${projectSettings.disableEditor}
     ${projectSettings.httpNodeAuth}
     ${projectSettings.httpNodeMiddleware}
+    ${projectSettings.apiMaxLength}
+    ${projectSettings.debugMaxLength}
     ${projectSettings.tcpInAllowInboundConnections}
     ${projectSettings.udpInAllowInboundConnections}
     httpServerOptions: {

--- a/test/unit/lib/runtimeSettings_spec.js
+++ b/test/unit/lib/runtimeSettings_spec.js
@@ -77,6 +77,8 @@ describe('Runtime Settings', function () {
 
             settings.should.not.have.property('httpNodeAuth')
             settings.should.not.have.property('httpNodeMiddleware')
+            settings.should.not.have.property('apiMaxLength')
+            settings.should.not.have.property('debugMaxLength')
         })
         it('includes ee-only settings when license applied', async function () {
             const result = runtimeSettings.getSettingsFile({
@@ -103,6 +105,8 @@ describe('Runtime Settings', function () {
                     disableEditor: true,
                     codeEditor: 'ace',
                     theme: 'forge-dark',
+                    apiMaxLength: '123',
+                    debugMaxLength: '456',
                     page: {
                         title: 'PAGE_TITLE',
                         favicon: 'PAGE_FAVICON'
@@ -130,6 +134,8 @@ describe('Runtime Settings', function () {
             settings.should.have.property('httpAdminRoot', '/red')
             settings.should.have.property('ui', { path: '/dash' })
             settings.should.have.property('disableEditor', true)
+            settings.should.have.property('apiMaxLength', '123')
+            settings.should.have.property('debugMaxLength', 456)
 
             settings.should.have.property('httpStorage', {
                 projectID: 'PROJECTID',


### PR DESCRIPTION
part of #3577 & 3581

## Description

<!-- Describe your changes in detail -->
Adds ability to change apiMaxLength and debugMaxLength Node-RED settings

EE only feature

## Related Issue(s)

<!-- What issue does this PR relate to? -->
#3577 & 3581

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

