### PR TITLE
Enable multiplayer by default

### DIFF
--- a/lib/runtimeSettings.js
+++ b/lib/runtimeSettings.js
@@ -291,6 +291,9 @@ module.exports = {
         tours: ${projectSettings.tours},
         palette: {
             catalogues: ${JSON.stringify(projectSettings.palette.catalogues)}
+        },
+        multiplayer: {
+            enabled: true
         }
     },
     nodesExcludes: ${JSON.stringify(projectSettings.palette.nodesExcludes)},


### PR DESCRIPTION
This enables the beta multiplayer feature by default. We may elect to restrict to certain team types before NR4 GAs, but for the super early beta, we can enable by default.