### PR TITLE
Add shell option to npm spawn command

### DIFF
--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -223,7 +223,7 @@ class Launcher {
                 const child = childProcess.spawn(
                     npmCommand,
                     ['install', '--omit=dev', '--no-audit', '--no-update-notifier', '--no-fund'],
-                    { windowsHide: true, cwd: path.join(this.settings.rootDir, this.settings.userDir), env: npmEnv })
+                    { windowsHide: true, cwd: path.join(this.settings.rootDir, this.settings.userDir), env: npmEnv, shell: true })
                 child.stdout.on('data', (data) => {
                     this.logBuffer.add({ level: 'system', msg: '[npm] ' + data })
                 })


### PR DESCRIPTION
Following the recent node 18/20 releases that block the use of spawn on Windows for `cmd` files without the `shell` option set, this PR sets the `shell` option.

This is only relevant for localfs installs on Windows.