### PR TITLE
Make the oauth callback URL relative

### DIFF
--- a/lib/auth/adminAuth.js
+++ b/lib/auth/adminAuth.js
@@ -13,7 +13,7 @@ module.exports = (options) => {
     const forgeURL = options.forgeURL
     const baseURL = options.baseURL
 
-    const callbackURL = `${baseURL}/auth/strategy/callback`
+    const callbackURL = '/auth/strategy/callback'
     const authorizationURL = `${forgeURL}/account/authorize`
     const tokenURL = `${forgeURL}/account/token`
     const userInfoURL = `${forgeURL}/api/v1/user`

--- a/lib/auth/httpAuthMiddleware.js
+++ b/lib/auth/httpAuthMiddleware.js
@@ -95,7 +95,7 @@ module.exports = {
         // any path
 
         const nodeUrl = new URL(options.baseURL)
-        const callbackURL = `${nodeUrl.origin}/_ffAuth/callback`
+        const callbackURL = '/_ffAuth/callback'
         const authorizationURL = `${options.forgeURL}/account/authorize`
         const tokenURL = `${options.forgeURL}/account/token`
         const userInfoURL = `${options.forgeURL}/api/v1/user`


### PR DESCRIPTION
part of FlowFuse/flowfuse#324

## Description

<!-- Describe your changes in detail -->
This allows oauth to redirect back to the original hostname, not just the FlowFuse generated one. This is in support of Custom Hostnames.

## Related Issue(s)

<!-- What issue does this PR relate to? -->
FlowFuse/flowfuse#324

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

