### PR TITLE
Fix auth handling when editor moved from default path

### DIFF
--- a/lib/auth/adminAuth.js
+++ b/lib/auth/adminAuth.js
@@ -11,9 +11,12 @@ module.exports = (options) => {
     const clientID = options.clientID
     const clientSecret = options.clientSecret
     const forgeURL = options.forgeURL
-    const baseURL = options.baseURL
-
-    const callbackURL = '/auth/strategy/callback'
+    const baseURL = new URL(options.baseURL)
+    let basePath = baseURL.pathname || ''
+    if (basePath.endsWith('/')) {
+        basePath = basePath.substring(0, basePath.length - 1)
+    }
+    const callbackURL = `${basePath}/auth/strategy/callback`
     const authorizationURL = `${forgeURL}/account/authorize`
     const tokenURL = `${forgeURL}/account/token`
     const userInfoURL = `${forgeURL}/api/v1/user`

--- a/lib/auth/httpAuthMiddleware.js
+++ b/lib/auth/httpAuthMiddleware.js
@@ -90,11 +90,8 @@ module.exports = {
 
         app.use(passport.initialize())
 
-        // Need to map `options.baseURL` (the editor url) to the node root url.
-        // We do not support moving node root off / - so we just need to strip off
-        // any path
-
-        const nodeUrl = new URL(options.baseURL)
+        // CallbackURL is set as a relative path - passport will prepend the appropriate
+        // hostname based on the request it is handling.
         const callbackURL = '/_ffAuth/callback'
         const authorizationURL = `${options.forgeURL}/account/authorize`
         const tokenURL = `${options.forgeURL}/account/token`


### PR DESCRIPTION
The recent change to make the callback urls relative to the current domain didn't take into account if the editor had been moved away from the default `/` path.

This fixes that by extracting the path component of `baseURL` and prepending it to the callback path.