### PR TITLE
Revert httpAdminCookieOptions

### DIFF
--- a/lib/runtimeSettings.js
+++ b/lib/runtimeSettings.js
@@ -200,11 +200,12 @@ function getSettingsFile (settings) {
 
     const httpAdminCookieOptions = { }
 
-    if (settings.forgeURL.includes('https://')) {
-        httpAdminCookieOptions.sameSite = 'None'
-        httpAdminCookieOptions.secure = true
-        httpAdminCookieOptions.partitioned = true
-    }
+    // Something here is causing direct access to the editor to fail in FFC.
+    // if (settings.forgeURL.includes('https://')) {
+    //     httpAdminCookieOptions.sameSite = 'None'
+    //     httpAdminCookieOptions.secure = true
+    //     httpAdminCookieOptions.partitioned = true
+    // }
 
     const settingsTemplate = `
 ${projectSettings.setupAuthMiddleware}


### PR DESCRIPTION
Something in the cookie options is causing direct access to the editor to fail authentication.

Removing to get things unblocked.