### PR TITLE
Generate absolute callback url ourselves

### DIFF
--- a/lib/auth/strategy.js
+++ b/lib/auth/strategy.js
@@ -1,4 +1,5 @@
 const util = require('util')
+const url = require('url')
 const OAuth2Strategy = require('passport-oauth2')
 
 function Strategy (options, verify) {
@@ -6,9 +7,41 @@ function Strategy (options, verify) {
     this._base = Object.getPrototypeOf(Strategy.prototype)
     this._base.constructor.call(this, this.options, verify)
     this.name = 'FlowFuse'
+    this.isSecure = /^https:/.test(options.authorizationURL)
+    this.isRelativeCallback = !/^https?:/.test(options.callbackURL)
 }
 
 util.inherits(Strategy, OAuth2Strategy)
+
+/**
+ * Patch the authenticate function so we can do per-request generation of the
+ * callback uri
+ */
+Strategy.prototype.__authenticate = Strategy.prototype.authenticate
+
+Strategy.prototype.authenticate = function (req, options) {
+    const strategyOptions = { ...options }
+
+    if (this.isRelativeCallback) {
+        // Get the base url of the request
+
+        // This logic comes from passport_oauth2/lib/utils - but we use our
+        // own check for whether to redirect to https or http based on the
+        // authorizationURL we've been provided
+        const app = req.app
+        let trustProxy = this._trustProxy
+        if (app && app.get && app.get('trust proxy')) {
+            trustProxy = true
+        }
+        const protocol = this.isSecure ? 'https' : 'http'
+        const host = (trustProxy && req.headers['x-forwarded-host']) || req.headers.host
+        const path = req.url || ''
+        const base = protocol + '://' + host + path
+        strategyOptions.callbackURL = (new url.URL(this.options.callbackURL, base)).toString()
+    }
+
+    return this.__authenticate(req, strategyOptions)
+}
 
 Strategy.prototype.userProfile = function (accessToken, done) {
     this._oauth2.useAuthorizationHeaderforGET(true)


### PR DESCRIPTION
Fixes #244 

## Description

This PR fixes the callback URL generation to map from relative to absolute URL on a per-request basis. We cannot use the built-in resolution used by `passport-oauth2` due to the way our current FFC architecture handles inbound https requests.

Instead, we identified whether it should use https or http based on the authorizationURL setting as that will be consistent.

I've tested this change in the staging env using a custom container including this change. Also testing on localhost/localfs with http.