### PR TITLE
Set CWD to storage dir

### DIFF
--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -365,7 +365,7 @@ class Launcher {
             windowsHide: true,
             env: appEnv,
             stdio: ['ignore', 'pipe', 'pipe'],
-            cwd: path.join(this.settings.rootDir, this.settings.userDir)
+            cwd: path.join(this.settings.rootDir, this.settings.userDir, 'storage')
         }
 
         const processArguments = [


### PR DESCRIPTION
part of FlowFuse/flowfuse#3056
## Description

<!-- Describe your changes in detail -->
Ensure that the Node-RED CWD is userDir/storage so files written without a path end up on the persistent volume.

**DO NOT MERGE BEFORE ALL THE DRIVERS ARE UPDATED**
I will add a check list for this.

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label


### Merge first
- [x] https://github.com/FlowFuse/driver-localfs/pull/135
- [x] https://github.com/FlowFuse/helm/pull/407
- [x] https://github.com/FlowFuse/driver-k8s/pull/163
