### PR TITLE
Set secure cookie options

### DIFF
--- a/lib/runtimeSettings.js
+++ b/lib/runtimeSettings.js
@@ -200,12 +200,12 @@ function getSettingsFile (settings) {
 
     const httpAdminCookieOptions = { }
 
-    // Something here is causing direct access to the editor to fail in FFC.
-    // if (settings.forgeURL.includes('https://')) {
-    //     httpAdminCookieOptions.sameSite = 'None'
-    //     httpAdminCookieOptions.secure = true
-    //     httpAdminCookieOptions.partitioned = true
-    // }
+    if (settings.forgeURL.includes('https://')) {
+        httpAdminCookieOptions.name = 'nr-ff-auth'
+        httpAdminCookieOptions.sameSite = 'None'
+        httpAdminCookieOptions.secure = true
+        httpAdminCookieOptions.partitioned = true
+    }
 
     const settingsTemplate = `
 ${projectSettings.setupAuthMiddleware}


### PR DESCRIPTION
## Description

Re-enable the secure cookie options in the nr settings file.

***Warning***

This change must *not* hit production with NR 4.0.0 or 4.0.1 as that could result in users being locked out of their instances unless they manually delete the `connect.sid` cookie.

With 4.0.2 (just about to be released), we can control the cookie name (as set in this PR) which will avoid the clash.