### PR TITLE
Map runtime settings for nr-assistant

### DIFF
--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -142,6 +142,8 @@ class Launcher {
         nodesDir.push(path.join(require.main.path, '..', '..', '@flowfuse', 'nr-project-nodes').replace(/\\/g, '/'))
         nodesDir.push(path.join(require.main.path, 'node_modules', '@flowfuse', 'nr-file-nodes').replace(/\\/g, '/'))
         nodesDir.push(path.join(require.main.path, '..', '..', '@flowfuse', 'nr-file-nodes').replace(/\\/g, '/'))
+        nodesDir.push(path.join(require.main.path, 'node_modules', '@flowfuse', 'nr-assistant').replace(/\\/g, '/'))
+        nodesDir.push(path.join(require.main.path, '..', '..', '@flowfuse', 'nr-assistant').replace(/\\/g, '/'))
         nodesDir.push(require.main.path)
 
         this.settings.nodesDir = nodesDir

--- a/lib/runtimeSettings.js
+++ b/lib/runtimeSettings.js
@@ -152,7 +152,7 @@ function getSettingsFile (settings) {
             enabled: settings.assistant.enabled, // overall enable/disable
             url: `${settings.forgeURL}/api/v1/assistant/`, // URL for the assistant service
             token: settings.projectToken,
-            requestTimeout: settings.requestTimeout || 60000 // timeout for assistant requests
+            requestTimeout: settings.assistant.requestTimeout || 60000 // timeout for assistant requests
         }
     }
 

--- a/lib/runtimeSettings.js
+++ b/lib/runtimeSettings.js
@@ -24,6 +24,7 @@ function getSettingsFile (settings) {
         },
         fileStore: null,
         projectLink: null,
+        assistant: null,
         httpNodeAuth: '',
         setupAuthMiddleware: '',
         httpNodeMiddleware: '',
@@ -144,6 +145,17 @@ function getSettingsFile (settings) {
             projectSettings.projectLink.useSharedSubscriptions = true
         }
     }
+
+    if (settings.assistant) {
+        // Enable the nr-assistant nodes when configured
+        projectSettings.assistant = {
+            enabled: settings.assistant.enabled, // overall enable/disable
+            url: `${settings.forgeURL}/api/v1/assistant/`, // URL for the assistant service
+            token: settings.projectToken,
+            requestTimeout: settings.requestTimeout || 60000 // timeout for assistant requests
+        }
+    }
+
     let contextStorage = ''
     if (settings.fileStore?.url) {
         // file nodes settings
@@ -327,7 +339,8 @@ module.exports = {
         projectID: '${settings.projectID}',
         launcherVersion: '${settings.launcherVersion}',
         ${projectSettings.fileStore ? 'fileStore: ' + JSON.stringify(projectSettings.fileStore) + ',' : ''}
-        ${projectSettings.projectLink ? 'projectLink: ' + JSON.stringify(projectSettings.projectLink) : ''}
+        ${projectSettings.projectLink ? 'projectLink: ' + JSON.stringify(projectSettings.projectLink) + ',' : ''}
+        ${projectSettings.assistant ? 'assistant: ' + JSON.stringify(projectSettings.assistant) : ''}
     },
     runtimeState: {
         enabled: true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
             "version": "2.5.1",
             "license": "Apache-2.0",
             "dependencies": {
+                "@flowfuse/nr-assistant": "^0.1.0",
                 "@flowfuse/nr-file-nodes": "^0.0.5",
                 "@flowfuse/nr-project-nodes": "^0.6.2",
                 "@node-red/util": "^3.1.0",
@@ -41,6 +42,24 @@
                 "sinon": "^17.0.1",
                 "sqlite3": "^5.1.6",
                 "yaml": "^2.1.3"
+            }
+        },
+        "../../../nr-assistant": {
+            "name": "@flowfuse/nr-assistant",
+            "version": "0.1.0",
+            "extraneous": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "got": "^11.8.6"
+            },
+            "devDependencies": {
+                "eslint": "^8.48.0",
+                "eslint-config-standard": "^17.1.0",
+                "eslint-plugin-html": "7.1.0",
+                "eslint-plugin-no-only-tests": "^3.1.0"
+            },
+            "engines": {
+                "node": ">=16.x"
             }
         },
         "node_modules/@aashutoshrathi/word-wrap": {
@@ -1029,6 +1048,17 @@
             },
             "engines": {
                 "node": ">=10"
+            }
+        },
+        "node_modules/@flowfuse/nr-assistant": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/@flowfuse/nr-assistant/-/nr-assistant-0.1.0.tgz",
+            "integrity": "sha512-ZzyQS2U7B7Td29j3AEjnw4UQ9UdUwI1McwiIvl8pucZeFJJX67YLIMCtaN97vqXYgIMSr6+H2Uz00e6t/bX1Qw==",
+            "dependencies": {
+                "got": "^11.8.6"
+            },
+            "engines": {
+                "node": ">=16.x"
             }
         },
         "node_modules/@flowfuse/nr-file-nodes": {

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     },
     "homepage": "https://github.com/FlowFuse/nr-launcher#readme",
     "dependencies": {
+        "@flowfuse/nr-assistant": "^0.1.0",
         "@flowfuse/nr-file-nodes": "^0.0.5",
         "@flowfuse/nr-project-nodes": "^0.6.2",
         "@node-red/util": "^3.1.0",

--- a/test/unit/lib/runtimeSettings_spec.js
+++ b/test/unit/lib/runtimeSettings_spec.js
@@ -411,26 +411,25 @@ describe('Runtime Settings', function () {
     })
     it('includes assistant settings when enabled', async function () {
         const result = runtimeSettings.getSettingsFile({
+            baseURL: 'https://BASEURL',
+            forgeURL: 'https://FORGEURL',
+            projectToken: 'ffxxx_1234567890',
             settings: {
                 palette: {
                     catalogue: ['foo', 'bar', 'baz']
-                },
-                assistant: {
-                    enabled: true,
-                    service: {
-                        url: 'http://localhost:9876',
-                        token: 'blah',
-                        requestTimeout: 60000
-                    }
                 }
+            },
+            assistant: {
+                enabled: true,
+                requestTimeout: 12345
             }
         })
         const settings = await loadSettings(result)
         settings.should.have.property('flowforge').and.be.an.Object()
         settings.flowforge.should.have.property('assistant')
-        settings.flowforge.projectLink.should.have.property('enabled', true)
-        settings.flowforge.projectLink.should.have.property('url', 'http://localhost:9876')
-        settings.flowforge.projectLink.should.have.property('token', 'blah')
-        settings.flowforge.projectLink.should.have.property('requestTimeout', 60000)
+        settings.flowforge.assistant.should.have.property('enabled', true)
+        settings.flowforge.assistant.should.have.property('url', 'https://FORGEURL/api/v1/assistant/')
+        settings.flowforge.assistant.should.have.property('token', 'ffxxx_1234567890')
+        settings.flowforge.assistant.should.have.property('requestTimeout', 12345)
     })
 })

--- a/test/unit/lib/runtimeSettings_spec.js
+++ b/test/unit/lib/runtimeSettings_spec.js
@@ -390,4 +390,28 @@ describe('Runtime Settings', function () {
         settings.editorTheme.palette.catalogues.should.have.length(1)
         settings.editorTheme.palette.catalogues[0].should.not.eql('foo') // will be NR default catalogue
     })
+    it('includes assistant settings when enabled', async function () {
+        const result = runtimeSettings.getSettingsFile({
+            settings: {
+                palette: {
+                    catalogue: ['foo', 'bar', 'baz']
+                },
+                assistant: {
+                    enabled: true,
+                    service: {
+                        url: 'http://localhost:9876',
+                        token: 'blah',
+                        requestTimeout: 60000
+                    }
+                }
+            }
+        })
+        const settings = await loadSettings(result)
+        settings.should.have.property('flowforge').and.be.an.Object()
+        settings.flowforge.should.have.property('assistant')
+        settings.flowforge.projectLink.should.have.property('enabled', true)
+        settings.flowforge.projectLink.should.have.property('url', 'http://localhost:9876')
+        settings.flowforge.projectLink.should.have.property('token', 'blah')
+        settings.flowforge.projectLink.should.have.property('requestTimeout', 60000)
+    })
 })


### PR DESCRIPTION
closes #255

## Description

* Adds `assistant` settings to runtime settings
* Includes `nr-assistant` in `nodesDir`

### TODO:
- [x] Add to package.json once `nr-assistant is published to NPM and push package+package lock
- [x] Tests

## Related Issue(s)

#255

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

