### PR TITLE
ci: Add `nr-assistant` dependency to `build and push` workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,7 +26,7 @@ on:
 
 jobs:
   build:
-    uses: 'flowfuse/github-actions-workflows/.github/workflows/build_node_package.yml@v0.14.0'
+    uses: 'flowfuse/github-actions-workflows/.github/workflows/build_node_package.yml@v0.19.0'
     with:
       node: '[
               {"version": "18", "tests": true, "lint": true},
@@ -37,13 +37,14 @@ jobs:
     if: |
       ( github.event_name == 'push' && github.ref == 'refs/heads/main' ) ||
       ( github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' )
-    uses: 'flowfuse/github-actions-workflows/.github/workflows/publish_node_package.yml@v0.1.0'
+    uses: 'flowfuse/github-actions-workflows/.github/workflows/publish_node_package.yml@v0.19.0'
     with:
       package_name: flowfuse-nr-launcher
       publish_package: true
       package_dependencies: |
         @flowfuse/nr-project-nodes
         @flowfuse/nr-file-nodes
+        @flowfuse/nr-assistant
     secrets:
       npm_registry_token: ${{ secrets.NPM_PUBLISH_TOKEN }}
   
@@ -52,7 +53,7 @@ jobs:
     if: |
       ( github.event_name == 'push' && github.ref == 'refs/heads/main' ) ||
       ( github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' )
-    uses: 'flowfuse/github-actions-workflows/.github/workflows/publish_node_package.yml@v0.1.0'
+    uses: 'flowfuse/github-actions-workflows/.github/workflows/publish_node_package.yml@v0.19.0'
     with:
       package_name: flowfuse-nr-theme
       publish_package: true


### PR DESCRIPTION
## Description

This pull requests adds `@flowfuse/nr-assistant` to the list of dependencies required during nightly build of `nr-launcher` package.
Additionally, it updates reusable workflows to their latest versions.

## Related Issue(s)

closes https://github.com/FlowFuse/nr-launcher/issues/259

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

