### PR TITLE
Add support for UIBuilder using storage

### DIFF
--- a/lib/runtimeSettings.js
+++ b/lib/runtimeSettings.js
@@ -159,7 +159,7 @@ function getSettingsFile (settings) {
 
     // all current drivers add settings.rootDir and settings.userDir
     if (settings.rootDir) {
-        const uibRoot = path.join(settings.rootDir, settings.userDir, 'storage', 'uibuilder')
+        const uibRoot = path.join(settings.rootDir, settings.userDir, 'storage', 'uibuilder').split(path.sep).join(path.posix.sep)
         projectSettings.uiBuilder = `uibuilder: { uibRoot: '${uibRoot}' },`
     }
 

--- a/lib/runtimeSettings.js
+++ b/lib/runtimeSettings.js
@@ -160,7 +160,7 @@ function getSettingsFile (settings) {
     // all current drivers add settings.rootDir and settings.userDir
     if (settings.rootDir) {
         const uibRoot = path.join(settings.rootDir, settings.userDir, 'storage', 'uibuilder').split(path.sep).join(path.posix.sep)
-        projectSettings.uiBuilder = `uibuilder: { uibRoot: '${uibRoot}' },`
+        projectSettings.uibuilder = { uibRoot }
     }
 
     let contextStorage = ''
@@ -358,7 +358,7 @@ module.exports = {
         next()
     },
     httpAdminCookieOptions: ${JSON.stringify(httpAdminCookieOptions)},
-    ${projectSettings.uiBuilder}
+    ${projectSettings.uibuilder ? 'uibuilder: ' + JSON.stringify(projectSettings.uibuilder) : ''}
 }
 `
     return settingsTemplate

--- a/lib/runtimeSettings.js
+++ b/lib/runtimeSettings.js
@@ -160,7 +160,7 @@ function getSettingsFile (settings) {
     // all current drivers add settings.rootDir and settings.userDir
     if (settings.rootDir) {
         const uibRoot = path.join(settings.rootDir, settings.userDir, 'storage', 'uibuilder')
-        projectSettings.uiBuilder = `uibuilder: { uibRoot: \'${uibRoot}\' },`
+        projectSettings.uiBuilder = `uibuilder: { uibRoot: '${uibRoot}' },`
     }
 
     let contextStorage = ''

--- a/lib/runtimeSettings.js
+++ b/lib/runtimeSettings.js
@@ -1,3 +1,4 @@
+const path = require('path')
 function getSettingsFile (settings) {
     const projectSettings = {
         credentialSecret: '',
@@ -154,6 +155,12 @@ function getSettingsFile (settings) {
             token: settings.projectToken,
             requestTimeout: settings.assistant.requestTimeout || 60000 // timeout for assistant requests
         }
+    }
+
+    // all current drivers add settings.rootDir and settings.userDir
+    if (settings.rootDir) {
+        const uibRoot = path.join(settings.rootDir, settings.userDir, 'storage', 'uibuilder')
+        projectSettings.uiBuilder = `uibuilder: { uibRoot: \'${uibRoot}\' },`
     }
 
     let contextStorage = ''
@@ -351,6 +358,7 @@ module.exports = {
         next()
     },
     httpAdminCookieOptions: ${JSON.stringify(httpAdminCookieOptions)},
+    ${projectSettings.uiBuilder}
 }
 `
     return settingsTemplate


### PR DESCRIPTION
fixes #253

## Description

<!-- Describe your changes in detail -->
Adds the required entry in settings.js to push uibuilder data to `userDir/storage`

## Related Issue(s)

<!-- What issue does this PR relate to? -->
#253 

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

