### PR TITLE
nr-launcher was not catching console.error output

### DIFF
--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -632,6 +632,31 @@ class Launcher {
                 linebreak = stdoutBuffer.indexOf('\n')
             }
         })
+        let stderrBuffer = ''
+        this.proc.stderr.on('data', (data) => {
+            // Do not assume `data` is a complete log record.
+            // Parse until newline
+            stderrBuffer = stderrBuffer + data
+            let linebreak = stderrBuffer.indexOf('\n')
+            while (linebreak > -1) {
+                const line = stderrBuffer.substring(0, linebreak)
+                if (line.length > 0) {
+                    if (line[0] === '{' && line[line.length - 1] === '}') {
+                        // In case something console.log's directly, we can't assume the line is JSON
+                        // from our logger
+                        try {
+                            this.logBuffer.add(JSON.parse(line))
+                        } catch (err) {
+                            this.logBuffer.add({ msg: line })
+                        }
+                    } else {
+                        this.logBuffer.add({ msg: line })
+                    }
+                }
+                stderrBuffer = stderrBuffer.substring(linebreak + 1)
+                linebreak = stderrBuffer.indexOf('\n')
+            }
+        })
     }
 
     async stop () {


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail -->
While testing #267 I noticed that the nr-launcher was not grabbing stderr from the NR process.

This ensures that stderr gets pushed to the forge app as part of the log stream

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

