### PR TITLE
Bump dependencies in preparation for release 2.7.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,9 @@
             "version": "2.6.0",
             "license": "Apache-2.0",
             "dependencies": {
-                "@flowfuse/nr-assistant": "^0.1.0",
-                "@flowfuse/nr-file-nodes": "^0.0.5",
-                "@flowfuse/nr-project-nodes": "^0.6.2",
+                "@flowfuse/nr-assistant": "^0.1.3",
+                "@flowfuse/nr-file-nodes": "^0.0.6",
+                "@flowfuse/nr-project-nodes": "^0.7.1",
                 "@node-red/util": "^3.1.0",
                 "body-parser": "^1.20.2",
                 "command-line-args": "^5.2.1",
@@ -1051,9 +1051,9 @@
             }
         },
         "node_modules/@flowfuse/nr-assistant": {
-            "version": "0.1.0",
-            "resolved": "https://registry.npmjs.org/@flowfuse/nr-assistant/-/nr-assistant-0.1.0.tgz",
-            "integrity": "sha512-ZzyQS2U7B7Td29j3AEjnw4UQ9UdUwI1McwiIvl8pucZeFJJX67YLIMCtaN97vqXYgIMSr6+H2Uz00e6t/bX1Qw==",
+            "version": "0.1.3",
+            "resolved": "https://registry.npmjs.org/@flowfuse/nr-assistant/-/nr-assistant-0.1.3.tgz",
+            "integrity": "sha512-cIUbOqAscs8rwMoWA7y171ixFYQAmNOa2k0AdLvGYl03U39WcLePVG+CGa2ad0qs5ALVP7++7DBqtvGcIFg6XA==",
             "dependencies": {
                 "got": "^11.8.6"
             },
@@ -1062,9 +1062,9 @@
             }
         },
         "node_modules/@flowfuse/nr-file-nodes": {
-            "version": "0.0.5",
-            "resolved": "https://registry.npmjs.org/@flowfuse/nr-file-nodes/-/nr-file-nodes-0.0.5.tgz",
-            "integrity": "sha512-TngLIdWYgISRC79M6QA7BwrBjW0lcyZPV+266HJ2jehMcVovXV5baShl15bY8dwlpxUpbiyCSDnm18HmdUTVtQ==",
+            "version": "0.0.6",
+            "resolved": "https://registry.npmjs.org/@flowfuse/nr-file-nodes/-/nr-file-nodes-0.0.6.tgz",
+            "integrity": "sha512-jc9Ab6vWCZXObyJ1KaZBiix8kBh0PCKWg419FMGfOHyOU5+nJPQw147PjB3Dif8shTdyZ0KsvKlpDNB5pxZeNA==",
             "dependencies": {
                 "got": "11.8.5",
                 "iconv-lite": "0.6.3"
@@ -1098,16 +1098,75 @@
             }
         },
         "node_modules/@flowfuse/nr-project-nodes": {
-            "version": "0.6.2",
-            "resolved": "https://registry.npmjs.org/@flowfuse/nr-project-nodes/-/nr-project-nodes-0.6.2.tgz",
-            "integrity": "sha512-aAwViJiUW40OWy0fvH5xAvxG+WPyWVIgOin54a436xYZIHgvS//DAavAjNS/XLVVAgbP9N2mfV79p1896uiHkg==",
+            "version": "0.7.1",
+            "resolved": "https://registry.npmjs.org/@flowfuse/nr-project-nodes/-/nr-project-nodes-0.7.1.tgz",
+            "integrity": "sha512-o25Q3Efg67SaxVF1mEiuldm45Y7l6cCCocKLZzroYfzosfnndlxCWO32bLJtE0uN/8O0gpun+Kiqk+zEX772Dw==",
             "dependencies": {
                 "got": "^11.8.6",
-                "mqtt": "^4.3.7"
+                "http-proxy-agent": "^7.0.2",
+                "https-proxy-agent": "^7.0.4",
+                "mqtt": "^4.3.7",
+                "proxy-from-env": "^1.1.0"
             },
             "engines": {
                 "node": ">=16.x"
             }
+        },
+        "node_modules/@flowfuse/nr-project-nodes/node_modules/agent-base": {
+            "version": "7.1.1",
+            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.1.tgz",
+            "integrity": "sha512-H0TSyFNDMomMNJQBn8wFV5YC/2eJ+VXECwOadZJT554xP6cODZHPX3H9QMQECxvrgiSOP1pHjy1sMWQVYJOUOA==",
+            "dependencies": {
+                "debug": "^4.3.4"
+            },
+            "engines": {
+                "node": ">= 14"
+            }
+        },
+        "node_modules/@flowfuse/nr-project-nodes/node_modules/debug": {
+            "version": "4.3.6",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.6.tgz",
+            "integrity": "sha512-O/09Bd4Z1fBrU4VzkhFqVgpPzaGbw6Sm9FEkBT1A/YBXQFGuuSxa1dN2nxgxS34JmKXqYx8CZAwEVoJFImUXIg==",
+            "dependencies": {
+                "ms": "2.1.2"
+            },
+            "engines": {
+                "node": ">=6.0"
+            },
+            "peerDependenciesMeta": {
+                "supports-color": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@flowfuse/nr-project-nodes/node_modules/http-proxy-agent": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+            "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+            "dependencies": {
+                "agent-base": "^7.1.0",
+                "debug": "^4.3.4"
+            },
+            "engines": {
+                "node": ">= 14"
+            }
+        },
+        "node_modules/@flowfuse/nr-project-nodes/node_modules/https-proxy-agent": {
+            "version": "7.0.5",
+            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.5.tgz",
+            "integrity": "sha512-1e4Wqeblerz+tMKPIq2EMGiiWW1dIjZOksyHWSUm1rmuvw/how9hBHZ38lAGj5ID4Ik6EdkOw7NmWPy6LAwalw==",
+            "dependencies": {
+                "agent-base": "^7.0.2",
+                "debug": "4"
+            },
+            "engines": {
+                "node": ">= 14"
+            }
+        },
+        "node_modules/@flowfuse/nr-project-nodes/node_modules/ms": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         },
         "node_modules/@gar/promisify": {
             "version": "1.1.3",
@@ -6821,6 +6880,11 @@
             "engines": {
                 "node": ">= 0.10"
             }
+        },
+        "node_modules/proxy-from-env": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+            "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
         },
         "node_modules/pseudomap": {
             "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -44,9 +44,9 @@
     },
     "homepage": "https://github.com/FlowFuse/nr-launcher#readme",
     "dependencies": {
-        "@flowfuse/nr-assistant": "^0.1.0",
-        "@flowfuse/nr-file-nodes": "^0.0.5",
-        "@flowfuse/nr-project-nodes": "^0.6.2",
+        "@flowfuse/nr-assistant": "^0.1.3",
+        "@flowfuse/nr-file-nodes": "^0.0.6",
+        "@flowfuse/nr-project-nodes": "^0.7.1",
         "@node-red/util": "^3.1.0",
         "body-parser": "^1.20.2",
         "command-line-args": "^5.2.1",


### PR DESCRIPTION
Updates FF dependencies to latest

* nr-assistant: 0.1.3
* nr-file-nodes: 0.0.6
* nr-project-nodes: 0.7.1
