### PR TITLE
Fix flushInterval in context module

### DIFF
--- a/lib/context/FFContextStorage.js
+++ b/lib/context/FFContextStorage.js
@@ -87,7 +87,6 @@ class FFContextStorage {
 
         async function getNext (cursor, limit) {
             const path = paginateUrl('cache', cursor, limit)
-            
             let response
             try {
                 response = await self.client.get(path, opts)
@@ -217,7 +216,7 @@ class FFContextStorage {
                             console.error('Error flushing pending context writes:' + err.toString())
                         })
                     })
-                }, self.flushInterval)
+                }, self.config.flushInterval)
             }
         } else if (typeof callback !== 'function') {
             throw new Error('This context store must be called asynchronously')


### PR DESCRIPTION
The context module was not honouring the flushInterval - instead, every write to context was triggering a flush.

This ensure the module picks up the flushInterval (default 30s) properly.