### PR TITLE
Config httpStatic based on instance settings

### DIFF
--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -131,6 +131,8 @@ class Launcher {
         this.settings.broker = this.options.broker
         this.settings.launcherVersion = this.options?.versions?.launcher || ''
 
+        this.settings.storageDir = path.join(this.settings.rootDir, this.settings.userDir, 'storage')
+
         // setup nodeDir to include the path to additional nodes and plugins
         const nodesDir = []
         if (Array.isArray(this.settings.nodesDir) && this.settings.nodesDir.length) {
@@ -367,7 +369,7 @@ class Launcher {
             windowsHide: true,
             env: appEnv,
             stdio: ['ignore', 'pipe', 'pipe'],
-            cwd: path.join(this.settings.rootDir, this.settings.userDir, 'storage')
+            cwd: this.settings.storageDir
         }
 
         const processArguments = [

--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -131,7 +131,7 @@ class Launcher {
         this.settings.broker = this.options.broker
         this.settings.launcherVersion = this.options?.versions?.launcher || ''
 
-        this.settings.storageDir = path.join(this.settings.rootDir, this.settings.userDir, 'storage')
+        this.settings.storageDir = path.normalize(path.join(this.settings.rootDir, this.settings.userDir, 'storage'))
 
         // setup nodeDir to include the path to additional nodes and plugins
         const nodesDir = []

--- a/lib/runtimeSettings.js
+++ b/lib/runtimeSettings.js
@@ -159,8 +159,17 @@ function getSettingsFile (settings) {
 
     // all current drivers add settings.rootDir and settings.userDir
     if (settings.rootDir) {
-        const uibRoot = path.join(settings.rootDir, settings.userDir, 'storage', 'uibuilder').split(path.sep).join(path.posix.sep)
+        const uibRoot = path.join(settings.storageDir, 'uibuilder').split(path.sep).join(path.posix.sep)
         projectSettings.uibuilder = { uibRoot }
+    }
+
+    if (settings.settings.httpStatic) {
+        // This is an array of httpStatic properties - however their path setting
+        // will currently be relative to cwd. For safety, map them to absolute paths:
+        projectSettings.httpStatic = settings.settings.httpStatic.map(staticSetting => {
+            staticSetting.path = path.join(settings.storageDir, staticSetting.path).split(path.sep).join(path.posix.sep)
+            return staticSetting
+        })
     }
 
     let contextStorage = ''
@@ -358,7 +367,8 @@ module.exports = {
         next()
     },
     httpAdminCookieOptions: ${JSON.stringify(httpAdminCookieOptions)},
-    ${projectSettings.uibuilder ? 'uibuilder: ' + JSON.stringify(projectSettings.uibuilder) : ''}
+    ${projectSettings.uibuilder ? 'uibuilder: ' + JSON.stringify(projectSettings.uibuilder) : ''},
+    ${projectSettings.httpStatic ? 'httpStatic: ' + JSON.stringify(projectSettings.httpStatic) : ''}
 }
 `
     return settingsTemplate

--- a/lib/runtimeSettings.js
+++ b/lib/runtimeSettings.js
@@ -165,11 +165,18 @@ function getSettingsFile (settings) {
 
     if (settings.settings.httpStatic) {
         // This is an array of httpStatic properties - however their path setting
-        // will currently be relative to cwd. For safety, map them to absolute paths:
-        projectSettings.httpStatic = settings.settings.httpStatic.map(staticSetting => {
-            staticSetting.path = path.join(settings.storageDir, staticSetting.path).split(path.sep).join(path.posix.sep)
-            return staticSetting
+        // will currently be relative to cwd. For safety, map them to absolute paths
+        // and validate they are not traversing out of the storageDir
+        const httpStatic = []
+        settings.settings.httpStatic.forEach(staticSetting => {
+            staticSetting.path = path.normalize(path.join(settings.storageDir, staticSetting.path))
+            if (staticSetting.path.startsWith(settings.storageDir)) {
+                httpStatic.push(staticSetting)
+            }
         })
+        if (httpStatic.length > 0) {
+            projectSettings.httpStatic = httpStatic
+        }
     }
 
     let contextStorage = ''


### PR DESCRIPTION
Closes https://github.com/FlowFuse/nr-launcher/issues/274
Part of https://github.com/FlowFuse/flowfuse/issues/4194

## Description

This sets `httpStatic` in the runtime settings based on the content received from the platform.

~I've followed the lead taken by the uibuilder work around path formatting - so it should work on Windows. Will need to verify that before release.~

Updated to avoid path traversal - ensures the resolved file system path is still within the storage path. To do this, I've used `path.normalize` which should handle all the necessary path separator changes. But - this will need testing on Windows (including a check on uibuilder as I normalise the new `storageDir` property which gets reused in the uibuilder piece).

The PR to include the `httpStatic` config from the platform is here: https://github.com/FlowFuse/flowfuse/pull/4388 