### PR TITLE
Pass through team-broker flag to instance settings

### DIFF
--- a/lib/runtimeSettings.js
+++ b/lib/runtimeSettings.js
@@ -142,6 +142,9 @@ function getSettingsFile (settings) {
             token: settings.projectToken,
             broker: { ...settings.broker }
         }
+        if (settings.features?.teamBroker) {
+            projectSettings.projectLink.teamBrokerEnabled = true
+        }
         if (settings.settings.ha?.replicas >= 2) {
             projectSettings.projectLink.useSharedSubscriptions = true
         }


### PR DESCRIPTION
Part of https://github.com/FlowFuse/nr-project-nodes/issues/114

## Description

Passes through the `teamBroker` feature flag to the runtime settings so the Project Nodes know to offer the Team Broker options.

NB: we don't yet have a Project Node release that knows about this setting - this is in preparation of that. This can be merged as-is.

The flag is passed to the launcher via the changes in https://github.com/FlowFuse/flowfuse/pull/4789
