### PR TITLE
Ensure restart on done only a running NR instance

### DIFF
--- a/lib/admin.js
+++ b/lib/admin.js
@@ -68,9 +68,16 @@ class AdminInterface {
                         }
                         response.send({})
                     }, 2000)
+                } else if (launcher.state === States.STOPPED) {
+                    try {
+                        await launcher.loadSettings()
+                        await launcher.start(request.body.safe ? States.SAFE : States.RUNNING)
+                    } catch (error) {
+                        await launcher.logAuditEvent('start-failed', { error })
+                    }
+                    response.send({})
                 } else {
                     // Might need a different response
-                    console.log('not running')
                     response.send({})
                 }
             } else if (request.body.cmd === 'start') {

--- a/lib/admin.js
+++ b/lib/admin.js
@@ -53,17 +53,26 @@ class AdminInterface {
                 //     response.status(409).send({err: "Not running"})
                 // }
             } else if (request.body.cmd === 'restart') {
-                await launcher.stop()
-                setTimeout(async () => {
-                    // Update the settings
-                    try {
-                        await launcher.loadSettings()
-                        await launcher.start(request.body.safe ? States.SAFE : States.RUNNING)
-                    } catch (error) {
-                        await launcher.logAuditEvent('start-failed', { error })
-                    }
+                if (launcher.state === States.RUNNING ||
+                    launcher.state === States.CRASHED ||
+                    launcher.state === States.SAFE
+                ) {
+                    await launcher.stop()
+                    setTimeout(async () => {
+                        // Update the settings
+                        try {
+                            await launcher.loadSettings()
+                            await launcher.start(request.body.safe ? States.SAFE : States.RUNNING)
+                        } catch (error) {
+                            await launcher.logAuditEvent('start-failed', { error })
+                        }
+                        response.send({})
+                    }, 2000)
+                } else {
+                    // Might need a different response
+                    console.log('not running')
                     response.send({})
-                }, 2000)
+                }
             } else if (request.body.cmd === 'start') {
                 if (launcher.getState() === States.RUNNING) {
                     response.status(409).send({ err: 'Already running' })


### PR DESCRIPTION
part of FlowFuse/flowfuse#4839

## Description

<!-- Describe your changes in detail -->
Prevents the restart command from running if the Node-RED instance is not actually running

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

