### PR TITLE
Allow Dashboards to be loaded in an iFrame

### DIFF
--- a/lib/runtimeSettings.js
+++ b/lib/runtimeSettings.js
@@ -65,9 +65,9 @@ function getSettingsFile (settings) {
                 dashboardSettings.push(`path: '${settings.settings.dashboardUI}'`)
             }
             if (authMiddlewareRequired && settings.settings.dashboardIFrame) {
-                dashboardSettings.push('middleware: [ flowforgeAuthMiddleware, DashboardIFrameMiddleware ]')
+                dashboardSettings.push('middleware: flowforgeAuthMiddleware.concat(DashboardIFrameMiddleware)')
             } else if (authMiddlewareRequired && !settings.settings.dashboardIFrame) {
-                dashboardSettings.push('middleware: [ flowforgeAuthMiddleware ]')
+                dashboardSettings.push('middleware: flowforgeAuthMiddleware')
             } else if (!authMiddlewareRequired && settings.settings.dashboardIFrame) {
                 dashboardSettings.push('middleware: [ DashboardIFrameMiddleware ]')
             }
@@ -255,7 +255,7 @@ function getSettingsFile (settings) {
 
     const settingsTemplate = `
 ${projectSettings.setupAuthMiddleware}
-const DashboardIFrameMiddleware = function(req,res,next) {
+const DashboardIFrameMiddleware = async function(req,res,next) {
     res.set("Content-Security-Policy", "frame-ancestors *");
     next()
 }

--- a/lib/runtimeSettings.js
+++ b/lib/runtimeSettings.js
@@ -64,8 +64,12 @@ function getSettingsFile (settings) {
             if (settings.settings.dashboardUI !== undefined) {
                 dashboardSettings.push(`path: '${settings.settings.dashboardUI}'`)
             }
-            if (authMiddlewareRequired) {
-                dashboardSettings.push('middleware: flowforgeAuthMiddleware')
+            if (authMiddlewareRequired && settings.settings.dashboardIFrame) {
+                dashboardSettings.push('middleware: [ flowforgeAuthMiddleware, DashboardIFrameMiddleware ]')
+            } else if (authMiddlewareRequired && !settings.settings.dashboardIFrame) {
+                dashboardSettings.push('middleware: [ flowforgeAuthMiddleware ]')
+            } else if (!authMiddlewareRequired && settings.settings.dashboardIFrame) {
+                dashboardSettings.push('middleware: [ DashboardIFrameMiddleware ]')
             }
             projectSettings.dashboardUI = `ui: { ${dashboardSettings.join(', ')}},`
         }
@@ -251,6 +255,10 @@ function getSettingsFile (settings) {
 
     const settingsTemplate = `
 ${projectSettings.setupAuthMiddleware}
+const DashboardIFrameMiddleware = function(req,res,next) {
+    res.set("Content-Security-Policy", "frame-ancestors *");
+    next()
+}
 module.exports = {
     flowFile: 'flows.json',
     flowFilePretty: true,


### PR DESCRIPTION
part of FlowFuse/flowfuse#4689

## Description

<!-- Describe your changes in detail -->
Sets `Content-Security-Policy: frame-ancestors *` for the dashboard routes

## Related Issue(s)

<!-- What issue does this PR relate to? -->
FlowFuse/flowfuse#4689

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

