### PR TITLE
Add Dashboard v2 max upload size

### DIFF
--- a/lib/runtimeSettings.js
+++ b/lib/runtimeSettings.js
@@ -1,4 +1,5 @@
 const path = require('path')
+const bytes = require('bytes')
 function getSettingsFile (settings) {
     const projectSettings = {
         credentialSecret: '',
@@ -70,6 +71,13 @@ function getSettingsFile (settings) {
                 dashboardSettings.push('middleware: flowforgeAuthMiddleware')
             } else if (!authMiddlewareRequired && settings.settings.dashboardIFrame) {
                 dashboardSettings.push('middleware: [ DashboardIFrameMiddleware ]')
+            }
+            if (settings.settings.apiMaxLength) {
+                try {
+                    dashboardSettings.push(`maxHttpBufferSize: ${bytes(settings.settings.apiMaxLength)}`)
+                } catch (err) {
+                    // failed to parse
+                }
             }
             projectSettings.dashboardUI = `ui: { ${dashboardSettings.join(', ')}},`
         }

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
                 "@flowfuse/nr-project-nodes": "^0.7.4",
                 "@node-red/util": "^3.1.0",
                 "body-parser": "^1.20.2",
+                "bytes": "^3.1.2",
                 "command-line-args": "^5.2.1",
                 "express": "^4.21.0",
                 "express-session": "^1.18.0",

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
         "@flowfuse/nr-project-nodes": "^0.7.4",
         "@node-red/util": "^3.1.0",
         "body-parser": "^1.20.2",
+        "bytes": "^3.1.2",
         "command-line-args": "^5.2.1",
         "express": "^4.21.0",
         "express-session": "^1.18.0",


### PR DESCRIPTION
part of FlowFuse/flowfuse#4933

## Description

<!-- Describe your changes in detail -->

Sets the max Dashboard v2 file upload size to match the max HTTP payload size for Node-RED

needs https://github.com/FlowFuse/node-red-dashboard/pull/1540

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

