### PR TITLE
include crash detail in audit log transmission

### DIFF
--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -603,7 +603,13 @@ class Launcher {
                 await this.logAuditEvent('stopped')
             } else {
                 this.state = States.CRASHED
-                await this.logAuditEvent('crashed')
+                // get last 20 lines of log
+                // NOTE: the log is added to the body in a specific property that should not actually
+                // be logged but rather extrated and examined to provide better reporting
+                // NOTE: 20 is typically enough to see the likes of Out Of Memory errors entries
+                const __launcherLog = this.getLog()?.toArray()?.slice(-20) || []
+                const body = { __launcherLog, info: { code, signal, info: 'Node-RED exited with non zero exit code' } }
+                await this.logAuditEvent('crashed', body)
 
                 // Only restart if our target state is not stopped
                 if (this.targetState !== States.STOPPED) {


### PR DESCRIPTION
closes #311

## Description

Includes last 20 log entries, exit code, exit signal and info for use in both Audit Log and "Crashed Email"

This is closely related to https://github.com/FlowFuse/flowfuse/issues/4934 but can be merged independently

## Related Issue(s)

owner: #311
parent: https://github.com/FlowFuse/flowfuse/issues/4653

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

