### PR TITLE
Catch errors from prom-client

### DIFF
--- a/lib/resources/resourcePlugin.js
+++ b/lib/resources/resourcePlugin.js
@@ -15,7 +15,7 @@ module.exports = (RED) => {
                     const metrics = await register.metrics()
                     res.send(metrics)
                 } catch (err) {
-                    res.status(500).send({error: err.toString()})
+                    res.status(500).send({ error: err.toString() })
                 }
             })
             RED.log.info('FlowFuse Metrics Plugin loaded')

--- a/lib/resources/resourcePlugin.js
+++ b/lib/resources/resourcePlugin.js
@@ -11,8 +11,12 @@ module.exports = (RED) => {
             const register = new Registry()
             collectDefaultMetrics({ register })
             RED.httpAdmin.get('/ff/metrics', async function (req, res) {
-                const metrics = await register.metrics()
-                res.send(metrics)
+                try {
+                    const metrics = await register.metrics()
+                    res.send(metrics)
+                } catch (err) {
+                    res.status(500).send({error: err.toString()})
+                }
             })
             RED.log.info('FlowFuse Metrics Plugin loaded')
         }


### PR DESCRIPTION
fixes FlowFuse/flowfuse#5072

## Description

<!-- Describe your changes in detail -->

Only seen on windows, but occasionally the cpu metrics go negative causing prom-client to throw and error about decrementing counters.

This catches the error and prevents Node-RED crashing.

Downside would be a missing a resource metrics entry.

## Related Issue(s)

<!-- What issue does this PR relate to? -->
FlowFuse/flowfuse#5072

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

