### PR TITLE
319 flush batching

### DIFF
--- a/lib/context/FFContextStorage.js
+++ b/lib/context/FFContextStorage.js
@@ -3,9 +3,6 @@ const got = require('got').default
 const safeJSONStringify = require('json-stringify-safe')
 const CONFIG_ERROR_MSG = 'Persistent context plugin cannot be used outside of FlowFuse EE environment'
 
-const sets = new Set()
-
-
 /**
  * @typedef {Object} FFContextStorageConfig - The configuration object for the FlowFuse Context Storage
  * @property {string} projectID - The FlowFuse project ID

--- a/lib/context/FFContextStorage.js
+++ b/lib/context/FFContextStorage.js
@@ -3,6 +3,9 @@ const got = require('got').default
 const safeJSONStringify = require('json-stringify-safe')
 const CONFIG_ERROR_MSG = 'Persistent context plugin cannot be used outside of FlowFuse EE environment'
 
+const sets = new Set()
+
+
 /**
  * @typedef {Object} FFContextStorageConfig - The configuration object for the FlowFuse Context Storage
  * @property {string} projectID - The FlowFuse project ID
@@ -111,24 +114,30 @@ class FFContextStorage {
             }
         }
         // update _flushPendingWrites to a real function
-        self._flushPendingWrites = function () {
+        self._flushPendingWrites = async function () {
             const scopes = Object.keys(self.pendingWrites)
             self.pendingWrites = {}
-            const promises = []
             const newContext = self.cache._export()
-            scopes.forEach(function (scope) {
-                const context = newContext[scope] || {}
-                const stringifiedContext = stringify(context)
-                if (stringifiedContext.circular && !self.knownCircularRefs[scope]) {
-                    console.warn('context.flowforge.error-circular', scope)
-                    self.knownCircularRefs[scope] = true
-                } else {
-                    delete self.knownCircularRefs[scope]
-                }
-                promises.push(self._writeCache(scope, stringifiedContext.json))
-            })
+            // Batch requests into a maximum of 5 at a time to avoid contention
+            // on the file-server
+            const chunkSize = 5
+            while (scopes.length > 0) {
+                // Grab a chunk of the pending scopes
+                const batch = scopes.splice(0, chunkSize)
+                // For each one, trigger the flush call and await all in the batch to complete
+                await Promise.all(batch.map((scope) => {
+                    const context = newContext[scope] || {}
+                    const stringifiedContext = stringify(context)
+                    if (stringifiedContext.circular && !self.knownCircularRefs[scope]) {
+                        console.warn('context.flowforge.error-circular', scope)
+                        self.knownCircularRefs[scope] = true
+                    } else {
+                        delete self.knownCircularRefs[scope]
+                    }
+                    return self._writeCache(scope, stringifiedContext.json)
+                }))
+            }
             delete self._pendingWriteTimeout
-            return Promise.all(promises)
         }
     }
 


### PR DESCRIPTION
Closes #319 
## Description

Currently the persistent context flush logic sends requests to the backend for all scopes that needed flushing without any regard of how many requests that would be.

Given the file server has to do locking on the database to properly calculate quotas for *each* request, flooding the backend with lots of requests causes a performance issue.

I have a test flow with 60 copies of a subflow that just writes a timestamp to its flow context - all wired to one inject node.

When triggered and the cache flushes, I see all 60 http requests made to the backend at the same time. The response time for each request increases markedly - the last few requests are close to 2000ms response time. With a single subflow, the response time is ~20ms. The response time increases the more subflow instances in the flow.

With this fix, the flush requests are made in batches of 5. The response time for each request remains stable at sub-30ms - the total time to flush is less with the batching in place than without.
