### PR TITLE
Ensure httpAdminRoot is included when generating metrics path

### DIFF
--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -544,7 +544,7 @@ class Launcher {
             parsedUrl.protocol = 'http:'
             parsedUrl.host = '127.0.0.1'
             parsedUrl.port = this.settings.port
-            parsedUrl.pathname = '/ff/metrics'
+            parsedUrl.pathname += (parsedUrl.pathname.endsWith('/') ? '' : '/') + 'ff/metrics'
             const pollUrl = parsedUrl.toString()
 
             const sample = await resourceSample(pollUrl, RESOURCE_POLL_INTERVAL)


### PR DESCRIPTION
Fixes #339 

The code was setting pathname of the url without consideration of an existing path. This fixes it by appending the path to what's already there (and avoiding the double `/`)