### PR TITLE
Add flow metrics to metrics plugin

### DIFF
--- a/lib/metricsLogger/index.js
+++ b/lib/metricsLogger/index.js
@@ -1,0 +1,63 @@
+const LRUMap = require('mnemonist/lru-map')
+const { Counter } = require('prom-client')
+
+let messageCounter = null
+let nodeReceiveCounter = null
+let nodeSendCounter = null
+
+function registerClient (promClientRegister) {
+    messageCounter = new Counter({
+        name: 'nodered_messages_total',
+        help: 'Count of unique messages handled by the flows',
+        registers: [promClientRegister]
+    })
+    nodeReceiveCounter = new Counter({
+        name: 'nodered_node_receive_events_total',
+        help: 'Count of node receive events',
+        registers: [promClientRegister]
+    })
+    nodeSendCounter = new Counter({
+        name: 'nodered_node_send_events_total',
+        help: 'Count of node send events',
+        registers: [promClientRegister]
+    })
+}
+const logger = (settings) => {
+    // Keep track of the 1000 most recently seen message ids
+    // That should be sufficient to avoid counting duplicates for most cases
+    const inflightMessages = new LRUMap(1000)
+    let loggedError = false
+    return function (msg) {
+        try {
+            if (messageCounter) {
+                // Only listen for node events
+                if (/^node/.test(msg.event)) {
+                    if (!inflightMessages.has(msg.msgid)) {
+                        messageCounter.inc()
+                    }
+                    inflightMessages.set(msg.msgid, msg.timestamp)
+                    if (/\.send$/.test(msg.event)) {
+                        nodeSendCounter.inc()
+                    }
+                    if (/\.receive$/.test(msg.event)) {
+                        nodeReceiveCounter.inc()
+                    }
+                }
+            }
+            loggedError = false // Reset the error flag on successful logging
+        } catch (err) {
+            // If the metrics logger fails, we don't want to crash the process
+            // so just log the error - but we don't want to flood the log in case
+            // of a persistent error, so we only log the first error
+            if (!loggedError) {
+                loggedError = true
+                console.error('Metrics logger error:', err)
+            }
+        }
+    }
+}
+
+module.exports = {
+    logger,
+    registerClient
+}

--- a/lib/resources/resourcePlugin.js
+++ b/lib/resources/resourcePlugin.js
@@ -10,6 +10,12 @@ module.exports = (RED) => {
             const Registry = client.Registry
             const register = new Registry()
             collectDefaultMetrics({ register })
+
+            // Pass the registry through to the metrics logger so it can
+            // record NR flow metrics
+            const metricsLogger = require('@flowfuse/nr-launcher/metricsLogger')
+            metricsLogger.registerClient(register)
+
             RED.httpAdmin.get('/ff/metrics', async function (req, res) {
                 try {
                     const metrics = await register.metrics()

--- a/lib/resources/sample.js
+++ b/lib/resources/sample.js
@@ -30,15 +30,17 @@ async function sampleResources (url, time) {
         })
         const parsed = pptf(res.body)
         parsed.forEach(metric => {
-            if (metric.name === 'nodejs_heap_space_size_total_bytes') {
-                metric.metrics.forEach(v => {
-                    response.hs = parseInt(v.value)
-                })
-            } else if (metric.name === 'nodejs_heap_space_size_used_bytes') {
-                metric.metrics.forEach(v => {
-                    response.hu = parseInt(v.value)
-                })
-            } else if (metric.name === 'process_resident_memory_bytes') {
+            // Removing these measures as they are not used and this code doesn't properly
+            // pull out the right value.
+            // if (metric.name === 'nodejs_heap_space_size_total_bytes') {
+            //     metric.metrics.forEach(v => {
+            //         response.hs = parseInt(v.value)
+            //     })
+            // } else if (metric.name === 'nodejs_heap_space_size_used_bytes') {
+            //     metric.metrics.forEach(v => {
+            //         response.hu = parseInt(v.value)
+            //     })
+            if (metric.name === 'process_resident_memory_bytes') {
                 response.ps = parseInt(metric.metrics[0].value) / (1024 * 1024)
             } else if (metric.name === 'process_cpu_seconds_total') {
                 const cpuTime = parseFloat(metric.metrics[0].value)
@@ -57,6 +59,12 @@ async function sampleResources (url, time) {
                 response.ela = parseFloat(metric.metrics[0].value)
             } else if (metric.name === 'nodejs_eventloop_lag_p99_seconds') {
                 response.el99 = parseFloat(metric.metrics[0].value)
+            } else if (metric.name === 'nodered_messages_total') {
+                response.nrmsgs = parseInt(metric.metrics[0].value)
+            } else if (metric.name === 'nodered_node_receive_events_total') {
+                response.nrrecv = parseInt(metric.metrics[0].value)
+            } else if (metric.name === 'nodered_node_send_events_total') {
+                response.nrsend = parseInt(metric.metrics[0].value)
             }
         })
     } catch (err) {

--- a/lib/runtimeSettings.js
+++ b/lib/runtimeSettings.js
@@ -353,6 +353,9 @@ module.exports = {
             loggingURL: '${settings.auditURL}',
             projectID: '${settings.projectID}',
             token: '${settings.projectToken}'
+        },
+        metricsLogger: {
+            level: 'off', metrics: true, handler: require('@flowfuse/nr-launcher/metricsLogger').logger,
         }
     },
     ${nodesDir}

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
                 "got": "^11.8.6",
                 "json-stringify-safe": "5.0.1",
                 "memorystore": "^1.6.7",
+                "mnemonist": "0.40.3",
                 "multer": "^2.0.0",
                 "oauth": "^0.9.15",
                 "parse-prometheus-text-format": "^1.1.1",
@@ -5788,6 +5789,15 @@
                 "node": ">=10"
             }
         },
+        "node_modules/mnemonist": {
+            "version": "0.40.3",
+            "resolved": "https://registry.npmjs.org/mnemonist/-/mnemonist-0.40.3.tgz",
+            "integrity": "sha512-Vjyr90sJ23CKKH/qPAgUKicw/v6pRoamxIEDFOF8uSgFME7DqPRpHgRTejWVjkdGg5dXj0/NyxZHZ9bcjH+2uQ==",
+            "license": "MIT",
+            "dependencies": {
+                "obliterator": "^2.0.4"
+            }
+        },
         "node_modules/mocha": {
             "version": "10.8.2",
             "resolved": "https://registry.npmjs.org/mocha/-/mocha-10.8.2.tgz",
@@ -6361,6 +6371,12 @@
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
+        },
+        "node_modules/obliterator": {
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/obliterator/-/obliterator-2.0.5.tgz",
+            "integrity": "sha512-42CPE9AhahZRsMNslczq0ctAEtqk8Eka26QofnqC346BZdHDySk3LWka23LI7ULIw11NmltpiLagIq8gBozxTw==",
+            "license": "MIT"
         },
         "node_modules/on-exit-leak-free": {
             "version": "2.1.2",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
     "description": "FlowFuse Launcher for running Node-RED",
     "exports": {
         "./auditLogger": "./lib/auditLogger/index.js",
+        "./metricsLogger": "./lib/metricsLogger/index.js",
         "./adminAuth": "./lib/auth/adminAuth.js",
         "./authMiddleware": "./lib/auth/httpAuthMiddleware.js",
         "./storage": "./lib/storage/index.js",
@@ -58,6 +59,7 @@
         "got": "^11.8.6",
         "json-stringify-safe": "5.0.1",
         "memorystore": "^1.6.7",
+        "mnemonist": "0.40.3",
         "multer": "^2.0.0",
         "oauth": "^0.9.15",
         "parse-prometheus-text-format": "^1.1.1",


### PR DESCRIPTION
Closes https://github.com/FlowFuse/flowfuse/issues/5713

## Description

This adds a Node-RED metrics logger to the launcher that exposes three counters:

 - `nodered_messages_total` - the number of messages handled by the flows. This uses the `msgid` property to deduplicate messages. It isn't 100% fool-proof, but good enough as a measure.
 - `nodered_node_receive_events_total` - the number of 'receive' events handled - ie, a message arriving at a node
 - `nodered_node_send_events_total` - the number of 'send' events handled - ie, a message sent from a node. NB: if a node has multiple wires on an output, this still shows up as a single send event.

These metrics are picked up by the launcher and exposed on the `resources` endpoint exposed by the launcher as `nrmsgs`, `nrrecv` and `nrsend`.

To track the message count, it uses a lru-cache to remember the last 1000 msgids seen. Not a fool-proof solution, but should be good enough for most cases.