### PR TITLE
Enable telemetry by default

### DIFF
--- a/lib/runtimeSettings.js
+++ b/lib/runtimeSettings.js
@@ -414,6 +414,9 @@ module.exports = {
         enabled: true,
         ui: true
     },
+    telemetry: {
+        enabled: true
+    },
     httpAdminMiddleware: function(req,res,next) {
         res.set("Content-Security-Policy", "frame-ancestors 'self' ${settings.forgeURL}");
         next()


### PR DESCRIPTION
## Description
Enable the usage telemetry feature by default for hosted instances running NR 4.1+. Users can still opt out via user settings.