### PR TITLE
Runtime entries for assistant mcp/completions config

### DIFF
--- a/lib/runtimeSettings.js
+++ b/lib/runtimeSettings.js
@@ -169,7 +169,7 @@ function getSettingsFile (settings) {
             mcp = { ...settings.assistant.mcp }
         }
 
-        let completions = { enabled: false } // default to disabled since URLs are required for the vocal and model
+        let completions = { enabled: true } // default to enabled
         if (settings.assistant.completions) {
             completions = { ...settings.assistant.completions }
         }

--- a/lib/runtimeSettings.js
+++ b/lib/runtimeSettings.js
@@ -164,12 +164,24 @@ function getSettingsFile (settings) {
     }
 
     if (settings.assistant) {
+        let mcp = { enabled: true } // default to enabled
+        if (typeof settings.assistant.mcp === 'object') {
+            mcp = { ...settings.assistant.mcp }
+        }
+
+        let completions = { enabled: false } // default to disabled since URLs are required for the vocal and model
+        if (settings.assistant.completions) {
+            completions = { ...settings.assistant.completions }
+        }
+
         // Enable the nr-assistant nodes when configured
         projectSettings.assistant = {
             enabled: settings.assistant.enabled, // overall enable/disable
             url: `${settings.forgeURL}/api/v1/assistant/`, // URL for the assistant service
             token: settings.projectToken,
-            requestTimeout: settings.assistant.requestTimeout || 60000 // timeout for assistant requests
+            requestTimeout: settings.assistant.requestTimeout || 60000, // timeout for assistant requests
+            mcp,
+            completions
         }
     }
 

--- a/test/unit/lib/runtimeSettings_spec.js
+++ b/test/unit/lib/runtimeSettings_spec.js
@@ -500,9 +500,9 @@ describe('Runtime Settings', function () {
         settings.flowforge.assistant.should.have.property('mcp')
         settings.flowforge.assistant.mcp.should.have.property('enabled', true) // defaults to true when not explicitly set
         settings.flowforge.assistant.should.have.property('completions')
-        settings.flowforge.assistant.completions.should.have.property('enabled', false) // defaults to false when not explicitly set
+        settings.flowforge.assistant.completions.should.have.property('enabled', true) // defaults to true when not explicitly set
     })
-    it('disables assistant mcp settings when config has disabled it', async function () {
+    it('disables assistant settings when config has disabled it', async function () {
         const result = runtimeSettings.getSettingsFile({
             baseURL: 'https://BASEURL',
             forgeURL: 'https://FORGEURL',
@@ -517,6 +517,9 @@ describe('Runtime Settings', function () {
                 requestTimeout: 12345,
                 mcp: {
                     enabled: false
+                },
+                completions: {
+                    enabled: false
                 }
             }
         })
@@ -526,6 +529,8 @@ describe('Runtime Settings', function () {
         settings.flowforge.assistant.should.have.property('enabled', true)
         settings.flowforge.assistant.should.have.property('mcp')
         settings.flowforge.assistant.mcp.should.have.property('enabled', false)
+        settings.flowforge.assistant.should.have.property('completions')
+        settings.flowforge.assistant.completions.should.have.property('enabled', false)
     })
     it('includes assistant completions settings when enabled', async function () {
         const result = runtimeSettings.getSettingsFile({
@@ -540,6 +545,9 @@ describe('Runtime Settings', function () {
             assistant: {
                 enabled: true,
                 requestTimeout: 12345,
+                mcp: {
+                    enabled: true
+                },
                 completions: {
                     enabled: true,
                     modelUrl: 'https://FORGEURL/api/v1/assistant/assets/completions/model.json',

--- a/test/unit/lib/runtimeSettings_spec.js
+++ b/test/unit/lib/runtimeSettings_spec.js
@@ -497,5 +497,63 @@ describe('Runtime Settings', function () {
         settings.flowforge.assistant.should.have.property('url', 'https://FORGEURL/api/v1/assistant/')
         settings.flowforge.assistant.should.have.property('token', 'ffxxx_1234567890')
         settings.flowforge.assistant.should.have.property('requestTimeout', 12345)
+        settings.flowforge.assistant.should.have.property('mcp')
+        settings.flowforge.assistant.mcp.should.have.property('enabled', true) // defaults to true when not explicitly set
+        settings.flowforge.assistant.should.have.property('completions')
+        settings.flowforge.assistant.completions.should.have.property('enabled', false) // defaults to false when not explicitly set
+    })
+    it('disables assistant mcp settings when config has disabled it', async function () {
+        const result = runtimeSettings.getSettingsFile({
+            baseURL: 'https://BASEURL',
+            forgeURL: 'https://FORGEURL',
+            projectToken: 'ffxxx_1234567890',
+            settings: {
+                palette: {
+                    catalogue: ['foo', 'bar', 'baz']
+                }
+            },
+            assistant: {
+                enabled: true,
+                requestTimeout: 12345,
+                mcp: {
+                    enabled: false
+                }
+            }
+        })
+        const settings = await loadSettings(result)
+        settings.should.have.property('flowforge').and.be.an.Object()
+        settings.flowforge.should.have.property('assistant')
+        settings.flowforge.assistant.should.have.property('enabled', true)
+        settings.flowforge.assistant.should.have.property('mcp')
+        settings.flowforge.assistant.mcp.should.have.property('enabled', false)
+    })
+    it('includes assistant completions settings when enabled', async function () {
+        const result = runtimeSettings.getSettingsFile({
+            baseURL: 'https://BASEURL',
+            forgeURL: 'https://FORGEURL',
+            projectToken: 'ffxxx_1234567890',
+            settings: {
+                palette: {
+                    catalogue: ['foo', 'bar', 'baz']
+                }
+            },
+            assistant: {
+                enabled: true,
+                requestTimeout: 12345,
+                completions: {
+                    enabled: true,
+                    modelUrl: 'https://FORGEURL/api/v1/assistant/assets/completions/model.json',
+                    vocabularyUrl: 'https://FORGEURL/api/v1/assistant/assets/completions/vocabulary.json'
+                }
+            }
+        })
+        const settings = await loadSettings(result)
+        settings.should.have.property('flowforge').and.be.an.Object()
+        settings.flowforge.should.have.property('assistant')
+        settings.flowforge.assistant.should.have.property('enabled', true)
+        settings.flowforge.assistant.should.have.property('completions')
+        settings.flowforge.assistant.completions.should.have.property('enabled', true)
+        settings.flowforge.assistant.completions.should.have.property('modelUrl', 'https://FORGEURL/api/v1/assistant/assets/completions/model.json')
+        settings.flowforge.assistant.completions.should.have.property('vocabularyUrl', 'https://FORGEURL/api/v1/assistant/assets/completions/vocabulary.json')
     })
 })


### PR DESCRIPTION
## Description

Adds runtime settings for the assistant features `mcp` and `completions`

* [`lib/runtimeSettings.js`](diffhunk://#diff-bb481800d6af84cd2fa3618af19dbfe4cc282403ec2130c3f8bdd76ead657405R167-R184): Added support for `mcp` (default enabled) and `completions` (default disabled) configurations within the assistant settings. These options permit enablement/disablement of the assistant feature on hosted instances

* [`test/unit/lib/runtimeSettings_spec.js`](diffhunk://#diff-af83fd1a8049dc9d005f8262be7432e974d3db245fccf32efc161dc02a6e9216R500-R557): Added tests to verify default values for `mcp` and `completions` settings, ensure `mcp` can be explicitly disabled, and validate the inclusion of `completions` settings when enabled.

## Related Issue(s)

closes #351

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

