### PR TITLE
Clear blueprint cache before repopulating

### DIFF
--- a/lib/storage/blueprintPlugin.js
+++ b/lib/storage/blueprintPlugin.js
@@ -12,7 +12,7 @@ module.exports = function (RED) {
     // We do not retrieve the blueprint list on every request; we get it once and cache the result.
     // The cache is expired after 2 minutes. Most interactions with the library will be short-lived
     // and within this interval - so this is the right balance between performance and freshness.
-    const blueprintCache = {}
+    let blueprintCache = {}
     let cacheLastRefreshedAt = 0
     const CACHE_EXPIRY_PERIOD = 2 * 60 * 1000 // 2 minutes in milliseconds
 
@@ -136,6 +136,7 @@ module.exports = function (RED) {
                         team: this.teamID
                     }
                 })
+                blueprintCache = {}
                 const blueprints = JSON.parse(result.body)
                 for (const blueprint of blueprints.blueprints) {
                     blueprintCache[blueprint.category || 'blueprints'] = blueprintCache[blueprint.category || 'blueprints'] || []


### PR DESCRIPTION
Fixes #353 

Clear the blueprint cache before repopulating it to avoid duplicate entries.