### PR TITLE
Add dependency of the new tables nodes

### DIFF
--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -146,6 +146,8 @@ class Launcher {
         }
         nodesDir.push(path.join(require.main.path, 'node_modules', '@flowfuse', 'nr-project-nodes').replace(/\\/g, '/'))
         nodesDir.push(path.join(require.main.path, '..', '..', '@flowfuse', 'nr-project-nodes').replace(/\\/g, '/'))
+        nodesDir.push(path.join(require.main.path, 'node_modules', '@flowfuse', 'nr-tables-nodes').replace(/\\/g, '/'))
+        nodesDir.push(path.join(require.main.path, '..', '..', '@flowfuse', 'nr-tables-nodes').replace(/\\/g, '/'))
         nodesDir.push(path.join(require.main.path, 'node_modules', '@flowfuse', 'nr-file-nodes').replace(/\\/g, '/'))
         nodesDir.push(path.join(require.main.path, '..', '..', '@flowfuse', 'nr-file-nodes').replace(/\\/g, '/'))
         nodesDir.push(path.join(require.main.path, 'node_modules', '@flowfuse', 'nr-assistant').replace(/\\/g, '/'))

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
                 "@flowfuse/nr-assistant": "^0.3.0",
                 "@flowfuse/nr-file-nodes": "^0.0.8",
                 "@flowfuse/nr-project-nodes": "^0.7.5",
+                "@flowfuse/nr-tables-nodes": "^0.1.0",
                 "@node-red/util": "^3.1.0",
                 "body-parser": "^1.20.2",
                 "bytes": "^3.1.2",
@@ -1175,6 +1176,19 @@
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
             "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        },
+        "node_modules/@flowfuse/nr-tables-nodes": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/@flowfuse/nr-tables-nodes/-/nr-tables-nodes-0.1.0.tgz",
+            "integrity": "sha512-Rf88qBBqcabeBColB9T2Y4vfHkNg/D7QBwTvs+9ftGiZpb6NuFtLWmNihZe+hPOvYzy0PQTeriY7YVGUffj4/g==",
+            "dependencies": {
+                "mustache": "^4.2.0",
+                "pg": "^8.14.1",
+                "pg-cursor": "^2.13.1"
+            },
+            "engines": {
+                "node": ">=16.x"
+            }
         },
         "node_modules/@gar/promisify": {
             "version": "1.1.3",
@@ -3012,15 +3026,6 @@
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
             "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
-        },
-        "node_modules/buffer-writer": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/buffer-writer/-/buffer-writer-2.0.0.tgz",
-            "integrity": "sha512-a7ZpuTZU1TRtnwyCNW3I5dc0wWNC3VR9S++Ewyk2HHZdrO3CQJqSpd+95Us590V6AL7JqUAH2IwZ/398PmNFgw==",
-            "dev": true,
-            "engines": {
-                "node": ">=4"
-            }
         },
         "node_modules/builtins": {
             "version": "5.0.1",
@@ -6519,6 +6524,14 @@
                 "mkdirp": "bin/cmd.js"
             }
         },
+        "node_modules/mustache": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/mustache/-/mustache-4.2.0.tgz",
+            "integrity": "sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==",
+            "bin": {
+                "mustache": "bin/mustache"
+            }
+        },
         "node_modules/natural-compare": {
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -6932,12 +6945,6 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/packet-reader": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/packet-reader/-/packet-reader-1.0.0.tgz",
-            "integrity": "sha512-HAKu/fG3HpHFO0AA8WE8q2g+gBJaZ9MG7fcKk+IJPLTGAD6Psw4443l+9DGRbOIh3/aXr7Phy0TjilYivJo5XQ==",
-            "dev": true
-        },
         "node_modules/parent-module": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -7053,24 +7060,21 @@
             "integrity": "sha512-KG8UEiEVkR3wGEb4m5yZkVCzigAD+cVEJck2CzYZO37ZGJfctvVptVO192MwrtPhzONn6go8ylnOdMhKqi4nfg=="
         },
         "node_modules/pg": {
-            "version": "8.11.3",
-            "resolved": "https://registry.npmjs.org/pg/-/pg-8.11.3.tgz",
-            "integrity": "sha512-+9iuvG8QfaaUrrph+kpF24cXkH1YOOUeArRNYIxq1viYHZagBxrTno7cecY1Fa44tJeZvaoG+Djpkc3JwehN5g==",
-            "dev": true,
+            "version": "8.16.3",
+            "resolved": "https://registry.npmjs.org/pg/-/pg-8.16.3.tgz",
+            "integrity": "sha512-enxc1h0jA/aq5oSDMvqyW3q89ra6XIIDZgCX9vkMrnz5DFTw/Ny3Li2lFQ+pt3L6MCgm/5o2o8HW9hiJji+xvw==",
             "dependencies": {
-                "buffer-writer": "2.0.0",
-                "packet-reader": "1.0.0",
-                "pg-connection-string": "^2.6.2",
-                "pg-pool": "^3.6.1",
-                "pg-protocol": "^1.6.0",
-                "pg-types": "^2.1.0",
-                "pgpass": "1.x"
+                "pg-connection-string": "^2.9.1",
+                "pg-pool": "^3.10.1",
+                "pg-protocol": "^1.10.3",
+                "pg-types": "2.2.0",
+                "pgpass": "1.0.5"
             },
             "engines": {
-                "node": ">= 8.0.0"
+                "node": ">= 16.0.0"
             },
             "optionalDependencies": {
-                "pg-cloudflare": "^1.1.1"
+                "pg-cloudflare": "^1.2.7"
             },
             "peerDependencies": {
                 "pg-native": ">=3.0.1"
@@ -7082,47 +7086,49 @@
             }
         },
         "node_modules/pg-cloudflare": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.1.1.tgz",
-            "integrity": "sha512-xWPagP/4B6BgFO+EKz3JONXv3YDgvkbVrGw2mTo3D6tVDQRh1e7cqVGvyR3BE+eQgAvx1XhW/iEASj4/jCWl3Q==",
-            "dev": true,
+            "version": "1.2.7",
+            "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.2.7.tgz",
+            "integrity": "sha512-YgCtzMH0ptvZJslLM1ffsY4EuGaU0cx4XSdXLRFae8bPP4dS5xL1tNB3k2o/N64cHJpwU7dxKli/nZ2lUa5fLg==",
             "optional": true
         },
         "node_modules/pg-connection-string": {
-            "version": "2.6.2",
-            "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.6.2.tgz",
-            "integrity": "sha512-ch6OwaeaPYcova4kKZ15sbJ2hKb/VP48ZD2gE7i1J+L4MspCtBMAx8nMgz7bksc7IojCIIWuEhHibSMFH8m8oA==",
-            "dev": true
+            "version": "2.9.1",
+            "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.9.1.tgz",
+            "integrity": "sha512-nkc6NpDcvPVpZXxrreI/FOtX3XemeLl8E0qFr6F2Lrm/I8WOnaWNhIPK2Z7OHpw7gh5XJThi6j6ppgNoaT1w4w=="
+        },
+        "node_modules/pg-cursor": {
+            "version": "2.15.3",
+            "resolved": "https://registry.npmjs.org/pg-cursor/-/pg-cursor-2.15.3.tgz",
+            "integrity": "sha512-eHw63TsiGtFEfAd7tOTZ+TLy+i/2ePKS20H84qCQ+aQ60pve05Okon9tKMC+YN3j6XyeFoHnaim7Lt9WVafQsA==",
+            "peerDependencies": {
+                "pg": "^8"
+            }
         },
         "node_modules/pg-int8": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
             "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
-            "dev": true,
             "engines": {
                 "node": ">=4.0.0"
             }
         },
         "node_modules/pg-pool": {
-            "version": "3.6.1",
-            "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.6.1.tgz",
-            "integrity": "sha512-jizsIzhkIitxCGfPRzJn1ZdcosIt3pz9Sh3V01fm1vZnbnCMgmGl5wvGGdNN2EL9Rmb0EcFoCkixH4Pu+sP9Og==",
-            "dev": true,
+            "version": "3.10.1",
+            "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.10.1.tgz",
+            "integrity": "sha512-Tu8jMlcX+9d8+QVzKIvM/uJtp07PKr82IUOYEphaWcoBhIYkoHpLXN3qO59nAI11ripznDsEzEv8nUxBVWajGg==",
             "peerDependencies": {
                 "pg": ">=8.0"
             }
         },
         "node_modules/pg-protocol": {
-            "version": "1.6.0",
-            "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.6.0.tgz",
-            "integrity": "sha512-M+PDm637OY5WM307051+bsDia5Xej6d9IR4GwJse1qA1DIhiKlksvrneZOYQq42OM+spubpcNYEo2FcKQrDk+Q==",
-            "dev": true
+            "version": "1.10.3",
+            "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.10.3.tgz",
+            "integrity": "sha512-6DIBgBQaTKDJyxnXaLiLR8wBpQQcGWuAESkRBX/t6OwA8YsqP+iVSiond2EDy6Y/dsGk8rh/jtax3js5NeV7JQ=="
         },
         "node_modules/pg-types": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
             "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
-            "dev": true,
             "dependencies": {
                 "pg-int8": "1.0.1",
                 "postgres-array": "~2.0.0",
@@ -7138,7 +7144,6 @@
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.5.tgz",
             "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
-            "dev": true,
             "dependencies": {
                 "split2": "^4.1.0"
             }
@@ -7147,7 +7152,6 @@
             "version": "4.2.0",
             "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
             "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
-            "dev": true,
             "engines": {
                 "node": ">= 10.x"
             }
@@ -7393,7 +7397,6 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
             "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
-            "dev": true,
             "engines": {
                 "node": ">=4"
             }
@@ -7402,7 +7405,6 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.0.tgz",
             "integrity": "sha512-xy3pmLuQqRBZBXDULy7KbaitYqLcmxigw14Q5sj8QBVLqEwXfeybIKVWiqAXTlcvdvb0+xkOtDbfQMOf4lST1w==",
-            "dev": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -7411,7 +7413,6 @@
             "version": "1.0.7",
             "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
             "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
-            "dev": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -7420,7 +7421,6 @@
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
             "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
-            "dev": true,
             "dependencies": {
                 "xtend": "^4.0.0"
             },

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
         "@flowfuse/nr-assistant": "^0.3.0",
         "@flowfuse/nr-file-nodes": "^0.0.8",
         "@flowfuse/nr-project-nodes": "^0.7.5",
+        "@flowfuse/nr-tables-nodes": "^0.1.0",
         "@node-red/util": "^3.1.0",
         "body-parser": "^1.20.2",
         "bytes": "^3.1.2",


### PR DESCRIPTION
## Description

- Adds` nr-tables-nodes` as a dependency of `nr-launcher` to ensure it's pre-installed on all Instances on FlowFuse
- Internal logic covers the situations whereby the nodes cannot be used (e.g. on Starter/Pro tiers), users are given notice in the NR Logs to upgrade their instances.

### Related Issues

https://github.com/FlowFuse/node-red/issues/54