### PR TITLE
Add support for nr-mqtt-nodes

### DIFF
--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -162,12 +162,12 @@ class Launcher {
         }
         nodesDir.push(path.join(require.main.path, 'node_modules', '@flowfuse', 'nr-project-nodes').replace(/\\/g, '/'))
         nodesDir.push(path.join(require.main.path, '..', '..', '@flowfuse', 'nr-project-nodes').replace(/\\/g, '/'))
-        nodesDir.push(path.join(require.main.path, 'node_modules', '@flowfuse', 'nr-tables-nodes').replace(/\\/g, '/'))
-        nodesDir.push(path.join(require.main.path, '..', '..', '@flowfuse', 'nr-tables-nodes').replace(/\\/g, '/'))
         nodesDir.push(path.join(require.main.path, 'node_modules', '@flowfuse', 'nr-file-nodes').replace(/\\/g, '/'))
         nodesDir.push(path.join(require.main.path, '..', '..', '@flowfuse', 'nr-file-nodes').replace(/\\/g, '/'))
         nodesDir.push(path.join(require.main.path, 'node_modules', '@flowfuse', 'nr-assistant').replace(/\\/g, '/'))
         nodesDir.push(path.join(require.main.path, '..', '..', '@flowfuse', 'nr-assistant').replace(/\\/g, '/'))
+        nodesDir.push(path.join(require.main.path, 'node_modules', '@flowfuse', 'nr-mqtt-nodes').replace(/\\/g, '/'))
+        nodesDir.push(path.join(require.main.path, '..', '..', '@flowfuse', 'nr-mqtt-nodes').replace(/\\/g, '/'))
         nodesDir.push(require.main.path)
 
         this.settings.nodesDir = nodesDir

--- a/lib/runtimeSettings.js
+++ b/lib/runtimeSettings.js
@@ -26,6 +26,7 @@ function getSettingsFile (settings) {
         },
         fileStore: null,
         projectLink: null,
+        mqttNodes: null,
         assistant: null,
         httpNodeAuth: '',
         setupAuthMiddleware: '',
@@ -172,6 +173,21 @@ function getSettingsFile (settings) {
         }
         if (settings.settings.ha?.replicas >= 2) {
             projectSettings.projectLink.useSharedSubscriptions = true
+        }
+    }
+
+    if (settings.features?.teamBroker && settings.broker) {
+        // Settings for nr-mqtt-nodes
+        projectSettings.mqttNodes = {
+            featureEnabled: true,
+            token: settings.projectToken,
+            linked: settings.mqttNodes?.linked,
+            ha: typeof settings.settings.ha?.replicas === 'number' && settings.settings.ha.replicas >= 2 ? settings.settings.ha.replicas : 0,
+            broker: {
+                url: settings.broker.url || '',
+                username: settings.mqttNodes?.username || `instance:${settings.projectID}`,
+                password: settings.mqttNodes?.password || settings.broker.password || ''
+            }
         }
     }
 
@@ -433,6 +449,7 @@ module.exports = {
         launcherVersion: '${settings.launcherVersion}',
         ${projectSettings.fileStore ? 'fileStore: ' + JSON.stringify(projectSettings.fileStore) + ',' : ''}
         ${projectSettings.projectLink ? 'projectLink: ' + JSON.stringify(projectSettings.projectLink) + ',' : ''}
+        ${projectSettings.mqttNodes ? 'mqttNodes: ' + JSON.stringify(projectSettings.mqttNodes) + ',' : ''}
         ${projectSettings.assistant ? 'assistant: ' + JSON.stringify(projectSettings.assistant) + ',' : ''}
         ${settings.features?.tables ? `tables: {token: '${settings.projectToken}'}` : ''}
     },

--- a/test/unit/lib/runtimeSettings_spec.js
+++ b/test/unit/lib/runtimeSettings_spec.js
@@ -585,4 +585,128 @@ describe('Runtime Settings', function () {
         settings.httpNodeCors.should.have.property('origin', '*')
         settings.httpNodeCors.should.have.property('methods', 'GET,POST,PUT,HEAD')
     })
+    it('Does not include mqttNodes settings when teamBroker feature is disabled', async function () {
+        const result = runtimeSettings.getSettingsFile({
+            baseURL: 'https://BASEURL',
+            forgeURL: 'https://FORGEURL',
+            projectToken: 'ffxxx_1234567890',
+            projectID: 'abcdefgh-1234-abcd-ef12-aa11bb22cc33',
+            settings: {
+                palette: {
+                    catalogue: ['foo', 'bar', 'baz']
+                }
+            },
+            features: {
+                teamBroker: false
+            },
+            broker: {
+                url: 'BROKERURL',
+                username: 'BROKERUSERNAME',
+                password: 'BROKERPASSWORD'
+            },
+            mqttNodes: {
+                linked: true,
+                username: 'instance:abcdefgh-1234-abcd-ef12-aa11bb22cc33'
+            }
+
+        })
+        const settings = await loadSettings(result)
+        settings.should.have.property('flowforge').and.be.an.Object()
+        settings.flowforge.should.not.have.property('mqttNodes')
+    })
+    it('Does not include mqttNodes settings when broker settings are not provided', async function () {
+        const result = runtimeSettings.getSettingsFile({
+            baseURL: 'https://BASEURL',
+            forgeURL: 'https://FORGEURL',
+            projectToken: 'ffxxx_1234567890',
+            projectID: 'abcdefgh-1234-abcd-ef12-aa11bb22cc33',
+            settings: {
+                palette: {
+                    catalogue: ['foo', 'bar', 'baz']
+                }
+            },
+            features: {
+                teamBroker: true
+            },
+            broker: null,
+            mqttNodes: {
+                linked: true,
+                username: 'instance:abcdefgh-1234-abcd-ef12-aa11bb22cc33'
+            }
+
+        })
+        const settings = await loadSettings(result)
+        settings.should.have.property('flowforge').and.be.an.Object()
+        settings.flowforge.should.not.have.property('mqttNodes')
+    })
+    it('includes mqttNodes settings when valid settings are provided', async function () {
+        const result = runtimeSettings.getSettingsFile({
+            baseURL: 'https://BASEURL',
+            forgeURL: 'https://FORGEURL',
+            projectToken: 'ffxxx_1234567890',
+            projectID: 'abcdefgh-1234-abcd-ef12-aa11bb22cc33',
+            settings: {
+                palette: {
+                    catalogue: ['foo', 'bar', 'baz']
+                }
+            },
+            features: {
+                teamBroker: true
+            },
+            broker: {
+                url: 'BROKERURL',
+                username: 'BROKERUSERNAME',
+                password: 'BROKERPASSWORD'
+            },
+            mqttNodes: {
+                linked: true
+            }
+
+        })
+        const settings = await loadSettings(result)
+        settings.should.have.property('flowforge').and.be.an.Object()
+        settings.flowforge.should.have.property('mqttNodes')
+        settings.flowforge.mqttNodes.should.have.property('featureEnabled', true)
+        settings.flowforge.mqttNodes.should.have.property('token', 'ffxxx_1234567890')
+        settings.flowforge.mqttNodes.should.have.property('broker').and.be.an.Object()
+        settings.flowforge.mqttNodes.broker.should.have.property('url', 'BROKERURL')
+        settings.flowforge.mqttNodes.broker.should.have.property('username', 'instance:abcdefgh-1234-abcd-ef12-aa11bb22cc33')
+        settings.flowforge.mqttNodes.broker.should.have.property('password', 'BROKERPASSWORD')
+    })
+    it('mqttNodes settings for username and password can be overridden when provided', async function () {
+        const result = runtimeSettings.getSettingsFile({
+            baseURL: 'https://BASEURL',
+            forgeURL: 'https://FORGEURL',
+            projectToken: 'ffxxx_1234567890',
+            projectID: 'abcdefgh-1234-abcd-ef12-aa11bb22cc33',
+            settings: {
+                palette: {
+                    catalogue: ['foo', 'bar', 'baz']
+                }
+            },
+            features: {
+                teamBroker: true
+            },
+            broker: {
+                url: 'BROKERURL',
+                username: 'BROKERUSERNAME',
+                password: 'BROKERPASSWORD'
+            },
+            mqttNodes: {
+                linked: true,
+                username: 'instance:xxxx-yyyyy-zzzzz',
+                password: 'different-password'
+            }
+
+        })
+        const settings = await loadSettings(result)
+        settings.should.have.property('flowforge').and.be.an.Object()
+        settings.flowforge.should.have.property('mqttNodes')
+        settings.flowforge.mqttNodes.should.have.property('featureEnabled', true)
+        settings.flowforge.mqttNodes.should.have.property('token', 'ffxxx_1234567890')
+        settings.flowforge.mqttNodes.should.have.property('broker').and.be.an.Object()
+        settings.flowforge.mqttNodes.broker.should.have.property('url', 'BROKERURL')
+        settings.flowforge.mqttNodes.broker.should.have.property('username', 'instance:xxxx-yyyyy-zzzzz')
+        settings.flowforge.mqttNodes.broker.should.have.property('password', 'different-password')
+    })
 })


### PR DESCRIPTION
## Description

* Adds `mqttNodes`object to `flowforge` object when broker settings are present and `teamBroker` feature flag is set
* Adds node to `nodesDir` in line with other plugins and FF nodes
* Adds tests to ensure settings are populated correctly (or excluded when broker settings are missing)

### Tests added:
```
▼ Runtime Settings
  ✔ Does not include mqttNodes settings when teamBroker feature is disabled
  ✔ Does not include mqttNodes settings when broker settings are not provided
  ✔ includes mqttNodes settings when valid settings are provided
  ✔ mqttNodes settings for username and password can be overridden when provided
```

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [x] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

