### PR TITLE
fix: Ensure the startup metrics endpoint complies with the OpenTelemetry specification

### DIFF
--- a/lib/admin.js
+++ b/lib/admin.js
@@ -96,25 +96,25 @@ class AdminInterface {
             response.setHeader('Content-Type', 'application/openmetrics-text')
             let metrics = '# HELP nr_created_timestamp Unix timestamp when the NR instance was created\n' +
                 '# TYPE nr_created_timestamp gauge\n' +
-                `nr_created_timestamp ${this.launcher.timing.created}\n\n`
+                `nr_created_timestamp ${this.launcher.timing.created}\n`
             if (Object.hasOwn(this.launcher.timing.loading, 'loading')) {
                 metrics += '# HELP nr_loading_duration_ms Time spent loading settings from forge app\n' +
                     '# TYPE nr_loading_duration_ms gauge\n' +
-                    `nr_loading_duration_ms ${this.launcher.timing.loading}\n\n`
+                    `nr_loading_duration_ms ${this.launcher.timing.loading}\n`
             }
 
             if (Object.hasOwn(this.launcher.timing, 'installing')) {
                 metrics += '# HELP nr_installing_duration_ms Time spent installing extra npm packages\n' +
                             '# TYPE nr_installing_duration_ms gauge\n' +
-                            `nr_installing_duration_ms ${this.launcher.timing.installing}\n\n`
+                            `nr_installing_duration_ms ${this.launcher.timing.installing}\n`
             }
 
             if (Object.hasOwn(this.launcher.timing, 'NRstartUp')) {
                 metrics += '# HELP nr_startup_duration_ms Elapsed time from NR exec to answering first health check\n' +
                             '# TYPE nr_startup_duration_ms gauge\n' +
-                            `nr_startup_duration_ms ${this.launcher.timing.NRstartUp}\n\n`
+                            `nr_startup_duration_ms ${this.launcher.timing.NRstartUp}\n`
             }
-
+            metrics += '# EOF\n'
             response.send(metrics)
         })
 


### PR DESCRIPTION
## Description

This pull request ensures, that startup metrics follows the OpenTelemetry specification when `application/openmetrics-text` content-type header is set.
In particular:
* blank lines between metrics have been removed
* `# EOF` line has been added at the end of the metrics page

## Related Issue(s)

https://github.com/FlowFuse/CloudProject/issues/815

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

