### PR TITLE
fix: data source for `nr_loading_duration_ms` metric

### DIFF
--- a/lib/admin.js
+++ b/lib/admin.js
@@ -97,7 +97,7 @@ class AdminInterface {
             let metrics = '# HELP nr_created_timestamp Unix timestamp when the NR instance was created\n' +
                 '# TYPE nr_created_timestamp gauge\n' +
                 `nr_created_timestamp ${this.launcher.timing.created}\n`
-            if (Object.hasOwn(this.launcher.timing.loading, 'loading')) {
+            if (Object.hasOwn(this.launcher.timing, 'loading')) {
                 metrics += '# HELP nr_loading_duration_ms Time spent loading settings from forge app\n' +
                     '# TYPE nr_loading_duration_ms gauge\n' +
                     `nr_loading_duration_ms ${this.launcher.timing.loading}\n`


### PR DESCRIPTION
## Description

This pull reuqest fixes the data source for `nr_loading_duration_ms` metric.

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

