### PR TITLE
feat: Introduce HTTP endpoint that indicates if dependencies installation has completed

### DIFF
--- a/lib/admin.js
+++ b/lib/admin.js
@@ -92,6 +92,16 @@ class AdminInterface {
             }
         })
 
+        app.get('/flowforge/ready', (request, response) => {
+            if (this.launcher.dependenciesInstallationReady &&
+                this.launcher.state !== States.STOPPED &&
+                this.launcher.state !== States.CRASHED) {
+                response.sendStatus(200)
+            } else {
+                response.sendStatus(503)
+            }
+        })
+
         app.get('/flowforge/startup', (request, response) => {
             response.setHeader('Content-Type', 'application/openmetrics-text')
             let metrics = '# HELP nr_created_timestamp Unix timestamp when the NR instance was created\n' +

--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -89,6 +89,7 @@ class Launcher {
         this.memoryAuditLogged = 0
 
         this.disableAutoSafeMode = false
+        this.dependenciesInstallationReady = false
         this.timing = {
             created: Date.now()
         }
@@ -115,6 +116,7 @@ class Launcher {
 
     async loadSettings () {
         this.state = States.LOADING
+        this.dependenciesInstallationReady = false
         const loadingStart = Date.now()
         this.logBuffer.add({ level: 'system', msg: 'Loading project settings' })
         const settingsURL = `${this.options.forgeURL}/api/v1/projects/${this.options.project}/settings`
@@ -214,6 +216,7 @@ class Launcher {
         this.timing.loading = Date.now() - loadingStart
         try {
             await this.updatePackage()
+            this.dependenciesInstallationReady = true
         } catch (error) {
             this.state = States.STOPPED
             this.logBuffer.add({ level: 'system', msg: 'Unable to install or update packages' })


### PR DESCRIPTION
## Description

This pull request introduces the `/flowforge/ready` endpoint. In this iteration, the endpoint indicates whether the installation of Node dependencies has completed. It returns an HTTP 200 status code if the installation was successful, and a 503 status code otherwise.

## Related Issue(s)

Closes https://github.com/FlowFuse/nr-launcher/issues/386

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

