### PR TITLE
Conditionally load nr-assistant plugin based on platform AI settings

### DIFF
--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -169,8 +169,11 @@ class Launcher {
         nodesDir.push(path.join(require.main.path, '..', '..', '@flowfuse', 'nr-tables-nodes').replace(/\\/g, '/'))
         nodesDir.push(path.join(require.main.path, 'node_modules', '@flowfuse', 'nr-file-nodes').replace(/\\/g, '/'))
         nodesDir.push(path.join(require.main.path, '..', '..', '@flowfuse', 'nr-file-nodes').replace(/\\/g, '/'))
-        nodesDir.push(path.join(require.main.path, 'node_modules', '@flowfuse', 'nr-assistant').replace(/\\/g, '/'))
-        nodesDir.push(path.join(require.main.path, '..', '..', '@flowfuse', 'nr-assistant').replace(/\\/g, '/'))
+        // Only include nr-assistant in nodesDir if the assistant is enabled by the platform
+        if (this.settings.assistant?.enabled === true) {
+            nodesDir.push(path.join(require.main.path, 'node_modules', '@flowfuse', 'nr-assistant').replace(/\\/g, '/'))
+            nodesDir.push(path.join(require.main.path, '..', '..', '@flowfuse', 'nr-assistant').replace(/\\/g, '/'))
+        }
         nodesDir.push(path.join(require.main.path, 'node_modules', '@flowfuse', 'nr-mqtt-nodes').replace(/\\/g, '/'))
         nodesDir.push(path.join(require.main.path, '..', '..', '@flowfuse', 'nr-mqtt-nodes').replace(/\\/g, '/'))
         nodesDir.push(path.join(require.main.path, 'node_modules', '@flowfuse', 'nr-subflow-export').replace(/\\/g, '/'))

--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -170,7 +170,7 @@ class Launcher {
         nodesDir.push(path.join(require.main.path, 'node_modules', '@flowfuse', 'nr-file-nodes').replace(/\\/g, '/'))
         nodesDir.push(path.join(require.main.path, '..', '..', '@flowfuse', 'nr-file-nodes').replace(/\\/g, '/'))
         // Only include nr-assistant in nodesDir if the assistant is enabled by the platform
-        if (this.settings.assistant?.enabled === true) {
+        if (this.settings.assistant?.enabled !== false) {
             nodesDir.push(path.join(require.main.path, 'node_modules', '@flowfuse', 'nr-assistant').replace(/\\/g, '/'))
             nodesDir.push(path.join(require.main.path, '..', '..', '@flowfuse', 'nr-assistant').replace(/\\/g, '/'))
         }


### PR DESCRIPTION
## Description

The nr-assistant plugin was previously unconditionally added to the Node-RED nodesDir. It is now only included when the platform reports `assistant.enabled` as true in the project settings response.
                                                                                                                                                                                                                                                                                                                              
  When the platform has AI features disabled (via the `ai` feature flag), the settings response returns `assistant.enabled: false`. The launcher now checks this value before adding the nr-assistant paths to nodesDir, preventing the plugin from being loaded into Node-RED.                                               

The FF platform provides backwards compatibility, in the form of the platform and team ai flags which default to true if not specifically opted out of.

  > [!IMPORTANT]
  > Changes to the assistant, AI platform, or AI team flags do not take effect on running instances immediately. All affected instances must be suspended and restarted for the nr-assistant plugin to be added or removed from the Node-RED nodesDir. The launcher reads settings from the platform on startup, so a restart is required to pick up the new configuration.

## Related Issue(s)

closes https://github.com/FlowFuse/flowfuse/issues/7325

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

