### PR TITLE
Fix issue with @media and @support tags being improperly flattened 

### DIFF
--- a/lib/theme/scripts/build.js
+++ b/lib/theme/scripts/build.js
@@ -99,17 +99,17 @@ async function generateTheme (options) {
     const colorCSS = []
     const nonColorCSS = []
 
-    let inKeyFrameBlock = false
+    let inAtRuleBlock = false
 
     lines.forEach(l => {
-        if (inKeyFrameBlock) {
+        if (inAtRuleBlock) {
             nonColorCSS.push(l)
             if (/^}/.test(l)) {
-                inKeyFrameBlock = false
+                inAtRuleBlock = false
             }
-        } else if (/^@keyframes/.test(l)) {
+        } else if (/^@\S.*\{\s*$/.test(l)) {
             nonColorCSS.push(l)
-            inKeyFrameBlock = true
+            inAtRuleBlock = true
         } else if (!/^ {2}/.test(l)) {
             colorCSS.push(l)
             nonColorCSS.push(l)


### PR DESCRIPTION
## Description

Generalized the `@keyframes` passthrough in `build.js` to cover all nested at-rule blocks (`@supports`, `@media`, etc.), since Node-RED 5 added a `@supports` scrollbar block whose nested declarations were being hoisted out of their selectors and breaking the Sass parse. Following the guideline already established by `@keyframes`, these blocks are now passed through whole rather than line-flattened.

## Related Issue(s)

N/A

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

