### PR TITLE
Disable visual notification of new NR version in the editor

### DIFF
--- a/lib/runtimeSettings.js
+++ b/lib/runtimeSettings.js
@@ -477,7 +477,8 @@ module.exports = {
         ui: true
     },
     telemetry: {
-        enabled: true
+        enabled: true,
+        updateNotification: false
     },
     httpAdminMiddleware: function(req,res,next) {
         res.set("Content-Security-Policy", "frame-ancestors 'self' ${settings.forgeURL}");


### PR DESCRIPTION
Node-RED will notify the user if there is a new version available. The notification takes them to the Node-RED GitHub releases page.

For FF users, this is not helpful; their local stack may not have been updated to include the new NR version, and even if it did, the notification doesn't help them update.

Ideally, we could hook into that notification to provide a custom trigger and link to direct the user at. In the meantime, this disables the UI notification as it causes confusion.