### PR TITLE
Only generate forge-l/d themes against v4.x css

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -17,6 +17,7 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           repository: node-red/node-red
+          ref: v4.x
           path: node-red
       - name: Build Theme
         run: npm run build-theme -- --src=node-red


### PR DESCRIPTION
The theme generator pulls node-red src to generate the custom forge-light/dark themes.

Given we only apply those themes to Node-RED 4 or earlier, we shouldn't be generating against v5 css.

This PR updates the workflow to checkout the `v4.x` branch of the node-red repo to ensure it uses the v4 style as source.