### PR TITLE
Always include forgeURL in dashboard CSP frame-ancestors

### DIFF
--- a/lib/runtimeSettings.js
+++ b/lib/runtimeSettings.js
@@ -68,13 +68,16 @@ function getSettingsFile (settings) {
             if (settings.settings.dashboardUI !== undefined) {
                 dashboardSettings.push(`path: '${settings.settings.dashboardUI}'`)
             }
-            if (authMiddlewareRequired && settings.settings.dashboardIFrame) {
-                dashboardSettings.push('middleware: flowforgeAuthMiddleware.concat(DashboardIFrameMiddleware)')
-            } else if (authMiddlewareRequired && !settings.settings.dashboardIFrame) {
-                dashboardSettings.push('middleware: flowforgeAuthMiddleware')
-            } else if (!authMiddlewareRequired && settings.settings.dashboardIFrame) {
-                dashboardSettings.push('middleware: [ DashboardIFrameMiddleware ]')
+            const middlewares = []
+            if (authMiddlewareRequired) {
+                middlewares.push('...flowforgeAuthMiddleware')
             }
+            if (settings.settings.dashboardIFrame) {
+                middlewares.push('DashboardIFrameMiddleware')
+            } else {
+                middlewares.push('DashboardCSPMiddleware')
+            }
+            dashboardSettings.push(`middleware: [ ${middlewares.join(', ')} ]`)
             if (settings.settings.apiMaxLength) {
                 try {
                     dashboardSettings.push(`maxHttpBufferSize: ${bytes(settings.settings.apiMaxLength)}`)
@@ -349,6 +352,10 @@ function getSettingsFile (settings) {
 
     const settingsTemplate = `
 ${projectSettings.setupAuthMiddleware}
+const DashboardCSPMiddleware = async function(req,res,next) {
+    res.set("Content-Security-Policy", "frame-ancestors 'self' ${settings.forgeURL}");
+    next()
+}
 const DashboardIFrameMiddleware = async function(req,res,next) {
     res.set("Content-Security-Policy", "frame-ancestors *");
     next()

--- a/test/unit/lib/runtimeSettings_spec.js
+++ b/test/unit/lib/runtimeSettings_spec.js
@@ -135,7 +135,12 @@ describe('Runtime Settings', function () {
             const settings = await loadSettings(result)
             settings.should.have.property('credentialSecret', 'foo')
             settings.should.have.property('httpAdminRoot', '/red')
-            settings.should.have.property('ui', { path: '/dash', maxHttpBufferSize: 123 })
+            settings.should.have.property('ui')
+            settings.ui.should.have.property('path', '/dash')
+            settings.ui.should.have.property('maxHttpBufferSize', 123)
+            settings.ui.should.have.property('middleware')
+            settings.ui.middleware.should.be.an.Array().and.have.length(1)
+            ;(typeof settings.ui.middleware[0]).should.equal('function')
             settings.should.have.property('disableEditor', true)
             settings.should.have.property('apiMaxLength', '123')
             settings.should.have.property('debugMaxLength', 456)
@@ -310,9 +315,24 @@ describe('Runtime Settings', function () {
             settings.should.have.property('ui')
             settings.ui.should.not.have.property('path')
             settings.ui.should.have.property('middleware')
-            settings.ui.middleware.should.be.an.Array()
+            settings.ui.middleware.should.be.an.Array().and.have.length(3)
             ;(typeof settings.ui.middleware[0]).should.equal('function')
             ;(typeof settings.ui.middleware[1]).should.equal('function')
+            ;(typeof settings.ui.middleware[2]).should.equal('function') // CSP middleware
+            // calling the CSP middleware function should add the baseline CSP header & call next
+            const headers = {}
+            let nextCalled = false
+            const res = {
+                set: function (header, value) {
+                    headers[header] = value
+                }
+            }
+            const next = function () {
+                nextCalled = true
+            }
+            settings.ui.middleware[2]({}, res, next)
+            headers.should.have.property('Content-Security-Policy', 'frame-ancestors \'self\' https://FORGEURL')
+            nextCalled.should.equal(true)
         } catch (err) {
             console.error(err)
             // Temporary fix as this module will not be found when running in CI
@@ -334,9 +354,24 @@ describe('Runtime Settings', function () {
             settings.should.have.property('ui')
             settings.ui.should.have.property('path', '/foo')
             settings.ui.should.have.property('middleware')
-            settings.ui.middleware.should.be.an.Array()
+            settings.ui.middleware.should.be.an.Array().and.have.length(3)
             ;(typeof settings.ui.middleware[0]).should.equal('function')
             ;(typeof settings.ui.middleware[1]).should.equal('function')
+            ;(typeof settings.ui.middleware[2]).should.equal('function') // CSP middleware
+            // calling the CSP middleware function should add the baseline CSP header & call next
+            const headers = {}
+            let nextCalled = false
+            const res = {
+                set: function (header, value) {
+                    headers[header] = value
+                }
+            }
+            const next = function () {
+                nextCalled = true
+            }
+            settings.ui.middleware[2]({}, res, next)
+            headers.should.have.property('Content-Security-Policy', 'frame-ancestors \'self\' https://FORGEURL')
+            nextCalled.should.equal(true)
         } catch (err) {
             // Temporary fix as this module will not be found when running in CI
             // until we publish the release of the new nr-auth module.
@@ -406,6 +441,36 @@ describe('Runtime Settings', function () {
         }
         settings.ui.middleware[0]({}, res, next)
         headers.should.have.property('Content-Security-Policy', 'frame-ancestors *')
+        nextCalled.should.equal(true)
+    })
+    it('includes baseline CSP middleware when dashboardUI is set without auth or iFrame', async function () {
+        const result = runtimeSettings.getSettingsFile({
+            baseURL: 'https://BASEURL',
+            forgeURL: 'https://FORGEURL',
+            settings: {
+                dashboardUI: '/foo'
+            }
+        })
+
+        const settings = await loadSettings(result)
+        settings.should.have.property('ui')
+        settings.ui.should.have.property('path', '/foo')
+        settings.ui.should.have.property('middleware')
+        settings.ui.middleware.should.be.an.Array().and.have.length(1)
+        ;(typeof settings.ui.middleware[0]).should.equal('function') // CSP middleware
+        // calling the middleware function should add the baseline CSP header & call next
+        const headers = {}
+        let nextCalled = false
+        const res = {
+            set: function (header, value) {
+                headers[header] = value
+            }
+        }
+        const next = function () {
+            nextCalled = true
+        }
+        settings.ui.middleware[0]({}, res, next)
+        headers.should.have.property('Content-Security-Policy', 'frame-ancestors \'self\' https://FORGEURL')
         nextCalled.should.equal(true)
     })
     it('includes HA settings when enabled', async function () {


### PR DESCRIPTION
## Description

The dashboard route's CSP `frame-ancestors` header now always includes `'self' <forgeURL>` as a baseline, so the FlowFuse app can embed a managed instance's dashboard without requiring the `dashboardIFrame` toggle. When `dashboardIFrame` is enabled, the header broadens to `frame-ancestors *` for third-party embedding.

Previously, the `!authMiddlewareRequired && !dashboardIFrame` case got no CSP middleware at all, meaning the first-party app couldn't embed the dashboard unless users explicitly turned on iframe support (which was overly permissive at `*`).

- Added `DashboardCSPMiddleware` that sets `frame-ancestors 'self' <forgeURL>` (mirrors the existing `httpAdminMiddleware` behavior)
- Restructured the dashboard middleware logic so CSP middleware is always applied, with `dashboardIFrame` only broadening it
- Updated existing tests and added a new test for the previously uncovered no-auth/no-iframe case

## Related Issue(s)

closes https://github.com/FlowFuse/flowfuse/issues/7870

## Checklist

<!-- https://flowfuse.com/handbook/development/#defining-done -->

 - [ ] I have read the [contribution guidelines](https://github.com/FlowFuse/flowfuse/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `FlowFuse/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `FlowFuse/CloudProject` to update values for Staging/Production
 - [ ] Link to Changelog Entry PR, or note why one is not needed.

## Labels

 - [ ] Includes a DB migration? -> add the `area:migration` label

